### PR TITLE
feat: create3 support for deploys

### DIFF
--- a/packages/rocketh/src/environment/types.ts
+++ b/packages/rocketh/src/environment/types.ts
@@ -1,3 +1,4 @@
+import {Abi, AbiConstructor, AbiError, AbiEvent, AbiFallback, AbiFunction, AbiReceive, Narrow} from 'abitype';
 import {
 	EIP1193Account,
 	EIP1193DATA,
@@ -7,14 +8,16 @@ import {
 	EIP1193TransactionReceipt,
 	EIP1193WalletProvider,
 } from 'eip-1193';
-import {Abi, Narrow, AbiError, AbiEvent, AbiConstructor, AbiFallback, AbiFunction, AbiReceive} from 'abitype';
-import type {Address, DeployContractParameters} from 'viem';
-import type {Chain} from 'viem';
+import type {Address, Chain, DeployContractParameters} from 'viem';
+import {
+	DeterministicDeploymentInfo,
+	type Create2DeterministicDeploymentInfo,
+	type Create3DeterministicDeploymentInfo,
+} from '../executor/index.js';
 import {ProgressIndicator} from '../internal/logging.js';
 import {TransactionHashTracker} from './providers/TransactionHashTracker.js';
-import {DeterministicDeploymentInfo} from '../executor/index.js';
 
-export type {Abi, AbiError, AbiEvent, AbiConstructor, AbiFallback, AbiFunction, AbiReceive};
+export type {Abi, AbiConstructor, AbiError, AbiEvent, AbiFallback, AbiFunction, AbiReceive};
 export type Libraries = {readonly [libraryName: string]: EIP1193Account};
 
 export type GasEstimate = 'infinite' | `${number}`;
@@ -291,7 +294,10 @@ export type ResolvedConfig<
 		name: string;
 		tags: string[];
 		fork?: boolean;
-		deterministicDeployment: DeterministicDeploymentInfo;
+		deterministicDeployment: {
+			create2: Create2DeterministicDeploymentInfo;
+			create3: Create3DeterministicDeploymentInfo;
+		};
 		nodeUrl?: string;
 		publicInfo?: {
 			name: string;


### PR DESCRIPTION
adds support for CREATE3 within both the config and deploy func.

CREATE3 is not an actual opcode, it's just used to describe a contract factory pattern that utilises CREATE2 to deploy a very minimal proxy that then deploys with CREATE, allowing deterministic deployments based purely on the deployer's address + a salt.

this implementation assumes the CREATE3 factory is to be deployed through the CREATE2 factory and uses the function `function deployDeterministic(bytes initCode memory, bytes32 salt)`.