### PR TITLE
feat(rocketh-deploy): log when reusing an unchanged deployment

### DIFF
--- a/packages/rocketh-deploy/src/index.ts
+++ b/packages/rocketh-deploy/src/index.ts
@@ -361,6 +361,7 @@ export function deploy(env: Environment): <TAbi extends Abi>(
 			}
 
 			if (bytecodeMatches && previousArgsData === argsData) {
+				logger.info(`reusing "${nameToDisplay}" at ${existingDeployment.address}`);
 				return {...(existingDeployment as Deployment<TAbi>), newlyDeployed: false};
 			}
 		}


### PR DESCRIPTION
Closes #39

### Problem

When a deploy script re-runs with no source changes, `@rocketh/deploy` correctly skips redeployment (`newlyDeployed: false`) but prints nothing — there's no indication the contract was reused, and no log of its address.

This came up while migrating Scaffold-ETH 2 to hardhat-deploy v2 ([scaffold-eth/scaffold-eth-2#1272](https://github.com/scaffold-eth/scaffold-eth-2/pull/1272)). In hardhat-deploy v1, a no-change re-deploy printed a line our users relied on:

```
$ yarn deploy
reusing "YourContract" at 0x5FbDB2315678afecb367f032d93F642f64180aa3
👋 Initial greeting: Building Unstoppable Apps!!!
```

With v2 the same re-run prints only the post-deploy script output, with no reuse/address line.


```
No contracts to compile
- Executing .../deploy/00_deploy_your_contract.ts
👋 Initial greeting: Building Unstoppable Apps!!!
```


### Root cause

The reuse branch in `packages/rocketh-deploy/src/index.ts` returns silently, and the only nearby log was commented out:

```ts
// if (existingDeployment) {
// 	logger.info(`existing deployment for ${nameToDisplay} at ${existingDeployment.address}`);
// }
```


### Change

Adds a single `logger.info` inside the matched-reuse branch, so it fires only when the deploy is genuinely skipped (bytecode + constructor args unchanged), matching the v1 "reusing" semantics:

```ts
if (bytecodeMatches && previousArgsData === argsData) {
	logger.info(`reusing "${nameToDisplay}" at ${existingDeployment.address}`);
	return {...(existingDeployment as Deployment<TAbi>), newlyDeployed: false};
}
```

I placed it in the matched branch rather than uncommenting the earlier `if (existingDeployment)` block on purpose: that earlier block fires for *any* existing deployment, including ones about to be redeployed because the bytecode changed, which would be misleading. Logging only on actual reuse keeps the output truthful.

Happy to adjust the wording, log level, or placement if you'd prefer something different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
