### PR TITLE
fix(hardhat-deploy): generate typed artifacts after every contracts build

### DIFF
--- a/.changeset/hardhat-deploy-generate-types-on-partial-builds.md
+++ b/.changeset/hardhat-deploy-generate-types-on-partial-builds.md
@@ -1,0 +1,7 @@
+---
+'hardhat-deploy': patch
+---
+
+Regenerate the typed artifacts after every successful contracts build, not only after full builds. The generation was hooked on `onCleanUpArtifacts`, which hardhat only triggers when the build performs an artifact cleanup, i.e. for a full build. The `deploy` task builds with `noTests: true`, which is not a full build, so the hook never fired during a deployment: solidity was recompiled with the `production` profile and `artifacts/` was up to date, but the generated typed artifacts that the deployment scripts actually import kept the content of the last full build (typically the `default` profile, optimizer off). Deployments could therefore ship unoptimized or outright stale bytecode.
+
+Generation now runs from `processArtifactsAfterSuccessfulBuild`, and the deprecated `onCleanUpArtifacts` hook is no longer registered. That hook was introduced in hardhat `3.6.0`, so the `hardhat` peer dependency moves from `^3.4.5` to `^3.6.0`.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tmp
 
 .ezx*
 my-rocketh-project/
+
+coverage

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@changesets/cli": "^2.31.0",
     "@nx/js": "^22.6.5",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "dorfl": "0.10.0",
     "ezx": "^0.0.18",
     "nx": "^22.6.5",

--- a/packages/hardhat-deploy/package.json
+++ b/packages/hardhat-deploy/package.json
@@ -58,7 +58,7 @@
 	"devDependencies": {
 		"@types/node": "^25.6.2",
 		"as-soon": "^0.1.6",
-		"hardhat": "3.6.0",
+		"hardhat": "^3.6.0",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.10"

--- a/packages/hardhat-deploy/package.json
+++ b/packages/hardhat-deploy/package.json
@@ -58,13 +58,14 @@
 	"devDependencies": {
 		"@types/node": "^25.6.2",
 		"as-soon": "^0.1.6",
-		"hardhat": "3.4.5",
+		"hardhat": "3.6.0",
 		"rimraf": "^6.1.3",
-		"typescript": "^6.0.3"
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@rocketh/node": "workspace:*",
-		"hardhat": "^3.4.5",
+		"hardhat": "^3.6.0",
 		"rocketh": "workspace:*"
 	},
 	"dependencies": {
@@ -80,6 +81,7 @@
 		"prepublishOnly": "cp ../../LICENSE LICENSE",
 		"build": "tsc --project tsconfig.json && cp src/v1-entry.cjs dist/",
 		"dev": "as-soon -w src pnpm build",
+		"test": "vitest",
 		"postinstall": "node -e \"require('fs').existsSync('./dist/postinstall.js') && require('child_process').spawnSync(process.execPath, ['./dist/postinstall.js'], {stdio: 'inherit'})\""
 	}
 }

--- a/packages/hardhat-deploy/src/hook-handlers/solidity.ts
+++ b/packages/hardhat-deploy/src/hook-handlers/solidity.ts
@@ -4,28 +4,35 @@ import {generateTypes} from '../generate-types.js';
 
 export default async (): Promise<Partial<SolidityHooks>> => {
 	const handlers: Partial<SolidityHooks> = {
-		async onCleanUpArtifacts(
-			context: HookContext,
-			artifactPaths: string[],
-			next: (nextContext: HookContext, artifactPaths: string[]) => Promise<void>,
-		) {
-			let artifactPathsToProcess = [context.config.paths.artifacts];
+		// `processArtifactsAfterSuccessfulBuild` is triggered after every successful
+		//  "contracts" build. The deprecated `onCleanUpArtifacts` hook is not used, as
+		//  hardhat only triggers it when a build performs an artifact cleanup, which the
+		//  `build` task only does for a *full* build (no `--no-tests` / `--no-contracts`
+		//  / explicit file list). The `deploy` task builds with `noTests: true`, so
+		//  generating from that hook would leave the typed artifacts, the ones the
+		//  deployment scripts import, holding the content of the last full build.
+		async processArtifactsAfterSuccessfulBuild(context: HookContext, artifactPaths: readonly string[]) {
+			if (artifactPaths.length === 0) {
+				return;
+			}
+
+			// the artifact paths are not forwarded to `generateTypes`: generation always
+			//  rescans `config.paths.artifacts` so the output describes the folder as it
+			//  is on disk, whoever wrote into it. The hook argument is only used above as
+			//  a "there is something to generate" guard.
+			const artifactPathsToProcess = [context.config.paths.artifacts];
 			// if (context.config.generateTypedArtifacts.externalArtifacts) {
 			// 	artifactPathsToProcess = artifactPathsToProcess.concat(
 			// 		context.config.generateTypedArtifacts.externalArtifacts
 			// 	);
 			// }
 
-			if (artifactPaths.length > 0) {
-				await generateTypes(
-					{
-						artifacts: artifactPathsToProcess,
-					},
-					context.config.generateTypedArtifacts,
-				);
-			}
-
-			return next(context, artifactPaths);
+			await generateTypes(
+				{
+					artifacts: artifactPathsToProcess,
+				},
+				context.config.generateTypedArtifacts,
+			);
 		},
 	};
 

--- a/packages/hardhat-deploy/templates/basic/package.json
+++ b/packages/hardhat-deploy/templates/basic/package.json
@@ -19,7 +19,7 @@
     "@rocketh/viem": "^0.19.1",
     "@types/node": "^25.0.10",
     "forge-std": "foundry-rs/forge-std#v1.9.4",
-    "hardhat": "^3.1.5",
+    "hardhat": "^3.6.0",
     "hardhat-deploy": "workspace:*",
     "rocketh": "^0.19.4",
     "typescript": "~6.0.3",

--- a/packages/hardhat-deploy/test/solidity-hooks.test.ts
+++ b/packages/hardhat-deploy/test/solidity-hooks.test.ts
@@ -1,0 +1,220 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {generateTypes} from '../src/generate-types.js';
+
+vi.mock('../src/generate-types.js', async (importOriginal) => {
+	const original = await importOriginal<typeof import('../src/generate-types.js')>();
+	return {
+		...original,
+		generateTypes: vi.fn(original.generateTypes),
+	};
+});
+
+const generateTypesMock = vi.mocked(generateTypes);
+
+// ----------------------------------------------------------------------------
+// minimal hardhat doubles
+// ----------------------------------------------------------------------------
+
+type Handlers = {
+	processArtifactsAfterSuccessfulBuild: (
+		context: any,
+		artifactPaths: readonly string[],
+		buildRootFilePaths: readonly string[],
+		buildOptions: {cleanupArtifacts: boolean},
+	) => Promise<void>;
+	onCleanUpArtifacts?: unknown;
+};
+
+async function getHandlers(): Promise<Handlers> {
+	const solidityHooks = (await import('../src/hook-handlers/solidity.js')).default;
+	return (await solidityHooks()) as unknown as Handlers;
+}
+
+function createContext(artifactsFolder: string, generatedFolder: string) {
+	return {
+		config: {
+			paths: {artifacts: artifactsFolder},
+			generateTypedArtifacts: {destinations: [{folder: generatedFolder, mode: 'typescript' as const}]},
+		},
+	};
+}
+
+/**
+ * A full build: hardhat cleans up the artifacts, then runs the hook.
+ */
+async function runFullBuild(handlers: Handlers, context: any, artifactPaths: string[]): Promise<void> {
+	await handlers.processArtifactsAfterSuccessfulBuild(context, artifactPaths, [], {cleanupArtifacts: true});
+}
+
+/**
+ * What `hardhat --network <network> deploy` does: the deploy task builds with
+ * `noTests: true`, which is not a full build, so hardhat performs no artifact
+ * cleanup. This is the case the previous `onCleanUpArtifacts` based generation
+ * never covered.
+ */
+async function runPartialBuild(handlers: Handlers, context: any, artifactPaths: string[]): Promise<void> {
+	await handlers.processArtifactsAfterSuccessfulBuild(context, artifactPaths, [], {cleanupArtifacts: false});
+}
+
+// ----------------------------------------------------------------------------
+// artifacts folder fixture
+// ----------------------------------------------------------------------------
+
+const BUILD_INFO_ID = 'solc-0_8_28-testbuildinfo';
+
+function writeArtifactsFolder(artifactsFolder: string, options: {bytecode: string}): string {
+	const contractFolder = path.join(artifactsFolder, 'src', 'Greeter.sol');
+	fs.mkdirSync(contractFolder, {recursive: true});
+	fs.mkdirSync(path.join(artifactsFolder, 'build-info'), {recursive: true});
+
+	const abi = [{type: 'function', name: 'greet', inputs: [], outputs: [], stateMutability: 'view'}];
+
+	fs.writeFileSync(
+		path.join(contractFolder, 'Greeter.json'),
+		JSON.stringify({
+			_format: 'hh3-artifact-1',
+			contractName: 'Greeter',
+			sourceName: 'src/Greeter.sol',
+			abi,
+			bytecode: options.bytecode,
+			deployedBytecode: options.bytecode,
+			linkReferences: {},
+			deployedLinkReferences: {},
+			immutableReferences: {},
+			inputSourceName: 'project/src/Greeter.sol',
+			buildInfoId: BUILD_INFO_ID,
+		}),
+	);
+
+	fs.writeFileSync(
+		path.join(artifactsFolder, 'build-info', `${BUILD_INFO_ID}.output.json`),
+		JSON.stringify({
+			output: {
+				contracts: {
+					'project/src/Greeter.sol': {
+						Greeter: {abi, evm: {}},
+					},
+				},
+			},
+		}),
+	);
+
+	return path.join(contractFolder, 'Greeter.json');
+}
+
+// ----------------------------------------------------------------------------
+
+describe('solidity hook handlers', () => {
+	let tmpFolder: string;
+	let artifactsFolder: string;
+	let generatedFolder: string;
+	let artifactPath: string;
+
+	beforeEach(() => {
+		vi.resetModules();
+		generateTypesMock.mockClear();
+
+		tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-deploy-hooks-'));
+		artifactsFolder = path.join(tmpFolder, 'artifacts');
+		generatedFolder = path.join(tmpFolder, 'generated');
+		artifactPath = writeArtifactsFolder(artifactsFolder, {bytecode: '0xaaaa'});
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpFolder, {recursive: true, force: true});
+	});
+
+	describe('when a build does not clean up artifacts (what `deploy` does)', () => {
+		it('generates the typed artifacts', async () => {
+			const handlers = await getHandlers();
+			const context = createContext(artifactsFolder, generatedFolder);
+
+			await runPartialBuild(handlers, context, [artifactPath]);
+
+			expect(generateTypesMock).toHaveBeenCalledTimes(1);
+			expect(fs.existsSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'))).toBe(true);
+		});
+
+		it('picks up artifacts recompiled since the last full build', async () => {
+			const handlers = await getHandlers();
+			const context = createContext(artifactsFolder, generatedFolder);
+
+			await runFullBuild(handlers, context, [artifactPath]);
+			const afterFullBuild = fs.readFileSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'), 'utf-8');
+			expect(afterFullBuild).toContain('0xaaaa');
+
+			// same thing `deploy` does: recompile (here with another build profile,
+			//  hence another bytecode) without a full build
+			writeArtifactsFolder(artifactsFolder, {bytecode: '0xbbbb'});
+			await runPartialBuild(handlers, context, [artifactPath]);
+
+			const afterPartialBuild = fs.readFileSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'), 'utf-8');
+			expect(afterPartialBuild).toContain('0xbbbb');
+			expect(afterPartialBuild).not.toContain('0xaaaa');
+		});
+	});
+
+	describe('when a build cleans up artifacts (a full build)', () => {
+		it('generates the typed artifacts exactly once', async () => {
+			const handlers = await getHandlers();
+			const context = createContext(artifactsFolder, generatedFolder);
+
+			await runFullBuild(handlers, context, [artifactPath]);
+
+			expect(generateTypesMock).toHaveBeenCalledTimes(1);
+			expect(fs.existsSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'))).toBe(true);
+		});
+	});
+
+	describe('guards and contract with hardhat', () => {
+		it('does not register the deprecated `onCleanUpArtifacts` hook', async () => {
+			const handlers = await getHandlers();
+
+			// generation is driven only by `processArtifactsAfterSuccessfulBuild`, which
+			//  hardhat runs for every successful "contracts" build
+			expect(handlers.onCleanUpArtifacts).toBeUndefined();
+		});
+
+		it('generates from the artifacts folder, not from the artifact paths the hook receives', async () => {
+			const handlers = await getHandlers();
+			const context = createContext(artifactsFolder, generatedFolder);
+
+			// the hook argument is only a "there is something to generate" guard: the
+			//  paths themselves are never read, the artifacts folder is rescanned
+			await runPartialBuild(handlers, context, ['/does/not/exist/Whatever.json']);
+
+			expect(generateTypesMock).toHaveBeenCalledWith(
+				{artifacts: [artifactsFolder]},
+				context.config.generateTypedArtifacts,
+			);
+			expect(fs.existsSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'))).toBe(true);
+		});
+
+		it('does not generate when there is no artifact at all', async () => {
+			const handlers = await getHandlers();
+			const context = createContext(artifactsFolder, generatedFolder);
+
+			await runPartialBuild(handlers, context, []);
+			await runFullBuild(handlers, context, []);
+
+			expect(generateTypesMock).not.toHaveBeenCalled();
+		});
+
+		it('generates for each hardhat instance', async () => {
+			const handlers = await getHandlers();
+			const contextA = createContext(artifactsFolder, generatedFolder);
+			const contextB = createContext(artifactsFolder, path.join(tmpFolder, 'generated-b'));
+
+			await runFullBuild(handlers, contextA, [artifactPath]);
+			await runFullBuild(handlers, contextB, [artifactPath]);
+
+			expect(generateTypesMock).toHaveBeenCalledTimes(2);
+			expect(fs.existsSync(path.join(generatedFolder, 'artifacts', 'Greeter.ts'))).toBe(true);
+			expect(fs.existsSync(path.join(tmpFolder, 'generated-b', 'artifacts', 'Greeter.ts'))).toBe(true);
+		});
+	});
+});

--- a/packages/hardhat-deploy/vitest.config.ts
+++ b/packages/hardhat-deploy/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-core/vitest.config.ts
+++ b/packages/rocketh-core/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-deploy/vitest.config.ts
+++ b/packages/rocketh-deploy/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-diamond/vitest.config.ts
+++ b/packages/rocketh-diamond/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-node/package.json
+++ b/packages/rocketh-node/package.json
@@ -61,7 +61,8 @@
 		"rimraf": "^6.1.3",
 		"rocketh": "workspace:*",
 		"typedoc": "^0.28.19",
-		"typescript": "^6.0.3"
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"rocketh": "workspace:*"
@@ -71,6 +72,7 @@
 		"build": "tsc --project tsconfig.json",
 		"dev": "as-soon -w src pnpm build",
 		"gen-docs": "typedoc --out docs src",
-		"serve-docs": "ipfs-emulator --only -d docs -p 8080"
+		"serve-docs": "ipfs-emulator --only -d docs -p 8080",
+		"test": "vitest"
 	}
 }

--- a/packages/rocketh-node/vitest.config.ts
+++ b/packages/rocketh-node/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-proxy/vitest.config.ts
+++ b/packages/rocketh-proxy/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-read-execute/vitest.config.ts
+++ b/packages/rocketh-read-execute/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/packages/rocketh-verifier/package.json
+++ b/packages/rocketh-verifier/package.json
@@ -56,7 +56,8 @@
 		"@types/node": "^25.6.0",
 		"as-soon": "^0.1.6",
 		"rimraf": "^6.1.3",
-		"typescript": "^6.0.3"
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@rocketh/node": "workspace:*"
@@ -64,6 +65,7 @@
 	"scripts": {
 		"prepublishOnly": "cp ../../LICENSE LICENSE",
 		"build": "tsc --project tsconfig.json",
-		"dev": "as-soon -w src pnpm build"
+		"dev": "as-soon -w src pnpm build",
+		"test": "vitest"
 	}
 }

--- a/packages/rocketh-verifier/vitest.config.ts
+++ b/packages/rocketh-verifier/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       dorfl:
         specifier: 0.10.0
         version: 0.10.0
@@ -52,7 +55,7 @@ importers:
         version: 2.0.0-alpha.18(@types/node@25.6.0)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(postcss@8.5.22)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
       zellij-launcher:
         specifier: ^0.0.1
         version: 0.0.1
@@ -88,7 +91,7 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6
       hardhat:
-        specifier: 3.6.0
+        specifier: ^3.6.0
         version: 3.6.0
       rimraf:
         specifier: ^6.1.3
@@ -98,7 +101,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh:
     dependencies:
@@ -154,7 +157,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-deploy:
     dependencies:
@@ -188,7 +191,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-diamond:
     dependencies:
@@ -231,7 +234,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-doc:
     dependencies:
@@ -376,6 +379,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-proxy:
     dependencies:
@@ -418,7 +424,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-read-execute:
     dependencies:
@@ -452,7 +458,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-router:
     dependencies:
@@ -571,6 +577,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh-viem:
     dependencies:
@@ -1226,6 +1235,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2049,6 +2062,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -2274,6 +2296,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2951,6 +2976,9 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -3090,9 +3118,24 @@ packages:
     peerDependencies:
       ws: ^8.21.0
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jest-diff@30.3.0:
     resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3392,6 +3435,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
@@ -5262,6 +5312,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
       '@changesets/config': 3.1.4
@@ -6095,6 +6147,20 @@ snapshots:
       vite: 8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.40(typescript@6.0.3)
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6314,6 +6380,12 @@ snapshots:
       lodash-es: 4.18.1
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
 
@@ -7009,6 +7081,8 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-escaper@2.0.2: {}
+
   html-void-elements@3.0.0: {}
 
   http-assert@1.5.0:
@@ -7161,12 +7235,27 @@ snapshots:
     dependencies:
       ws: 8.21.1
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jest-diff@30.3.0:
     dependencies:
       '@jest/diff-sequences': 30.3.0
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       pretty-format: 30.3.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -7505,6 +7594,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   mark.js@8.11.1: {}
 
@@ -8482,7 +8581,7 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.10(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -8506,10 +8605,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -8533,6 +8633,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,14 +88,17 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6
       hardhat:
-        specifier: 3.4.5
-        version: 3.4.5
+        specifier: 3.6.0
+        version: 3.6.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/rocketh:
     dependencies:
@@ -1569,36 +1572,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.32':
-    resolution: {integrity: sha512-uTJEmtlD7ZoULS2cE2CNunOirWxTML/c1k8CJBkMogtE33ArG0CzgL2OACEcZlsyje/PGBwUrsF1+WNjKZWxPA==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.33':
+    resolution: {integrity: sha512-CEaDltNmTRLyJPMwSVHNtYuXthJ3vm44SkRAQLiDYuhLbbzxAWmkCdnvKyo5QPmaRKxBGFwtahCJz2biBM43Ig==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.32':
-    resolution: {integrity: sha512-kWuTWKodlEbDjxWAern+bV67gdS6Tx0nE5izolt2jfAQ1KimYlMlKCtTnOIKmAn8NdXPrjmsPfTVMGdFSlvqdA==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.33':
+    resolution: {integrity: sha512-3V5XgzKLXFO+Cw0sWoO3ug2hHYL3VThskA1Iu98EPO44P4w0S6tW3bdsIH2OJPD+zi5RIHjg8H6HDZ+xeipXAA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.32':
-    resolution: {integrity: sha512-kMy/tvVf/FVebNaoFxtVW3NACBeipkqF+AV3hdzOx1Qsz/rXZkGgFD4Yf/F8TVMwLgWKvgV+QtCIAZ2E8CCXKw==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.33':
+    resolution: {integrity: sha512-5+1wkqlUEem9yhKX2AwSINlaiNk6NYfm4WbvaeEAmDZivLEDhW56BNe5+fuue1B4Fa50OONaimw9wEe3d1xYNA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.32':
-    resolution: {integrity: sha512-H/6SX6vrlvtEe1WIA6KSWeBig0ZSrHekE+beowDBfPjb0zgOAwbNvi0LSvXkYPCZPjInxonX4B7gGF2g2pULww==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.33':
+    resolution: {integrity: sha512-/Zr+9HxJfOSjtSTr3PkErSrGkP40j5op2koY1vVwsC1CqRiNnxKfXpwa6WH8zEUzIkEAGLq5ZwjD251irrf1uA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.32':
-    resolution: {integrity: sha512-jsCbYwPd5aezApKo6rBpngHTdAZSEkQtsf0/s84XZpGo4gCc4+5eWL6fSrqzJH/WopCS9BFQE6XCiylxYV8Elw==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.33':
+    resolution: {integrity: sha512-KrK/eUlVJo6FdHOBx9kXnzq8g+j8A2218ZVoVI/TJYgZFRXkhUI0tBeDmmdmfcRtk8J4Hw5QGRJVIXA2TAWUZQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.32':
-    resolution: {integrity: sha512-TyZqLiroByNWe3Gr/qJ6q5FpRcwTIXUHENv0PMfpj88BvJnBg879iwag5wtNYRrwx429e3SD6R3O8pgIcikldg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.33':
+    resolution: {integrity: sha512-o6Kmj4YKdRNZ6U4wn2hd0wyh3r2Pu0/RjBBiqs+zeeRopI/san7H4n6kIxe+8PbqlAcC48MI+oWLSNwnkqONwg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.32':
-    resolution: {integrity: sha512-PySTZVVWsRB0h008O6Ey5kdsGo/L+DoxAP7vypv1R9zw0BKFiQ9XhuCFx1sMu28sQ12OOXzOhDjhhZ87Tbfwbg==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.33':
+    resolution: {integrity: sha512-PPiOTOIShzhK7+i+QMDz6/0m2JcEHBMqCthLj8dru2RFhXT1Jory35u12awaVS2fU91flBg7zz7Qju4v8hrnLw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.32':
-    resolution: {integrity: sha512-syVtyDOyJv/IqfpmFsM6/rlpoq6XYl9j9urBLYGDci8pv/ow6vAdOxTrR9x2wE+cQi02TjeODG6QHMyr3B9Z2g==}
+  '@nomicfoundation/edr@0.12.0-next.33':
+    resolution: {integrity: sha512-+jwZcGgUKVUykqP+hbVEXClpqZbIdo/MztP/6Xp8DDmB8c+WxJvwCDmPrnfkV+s3NNj2lSDCyOZoPw9/UNcmXw==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/hardhat-errors@3.0.16':
@@ -2907,8 +2910,8 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
-  hardhat@3.4.5:
-    resolution: {integrity: sha512-smx65ClZttrZRKqagNSDEAlQAyAxJhh+c+07NDdlGmNK6ccNeDE9DVLB6td+JiPB9VvWSEy0UDY4WiBA47WbpQ==}
+  hardhat@3.6.0:
+    resolution: {integrity: sha512-6bYQk+UYdi4b/syTLYgsdAa3Mll0kaRdY2kJOylsaup/20f9gYM9+c3xmK2eCgW1wvmXSwKZTNaVDzDiNtK53Q==}
     hasBin: true
 
   has-flag@3.0.0:
@@ -5630,29 +5633,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.32': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.32': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.32': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.32': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.32': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.32': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.32': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.33': {}
 
-  '@nomicfoundation/edr@0.12.0-next.32':
+  '@nomicfoundation/edr@0.12.0-next.33':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.32
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.32
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.32
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.32
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.32
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.32
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.32
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.33
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.33
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.33
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.33
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.33
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.33
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.33
 
   '@nomicfoundation/hardhat-errors@3.0.16':
     dependencies:
@@ -6940,9 +6943,9 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  hardhat@3.4.5:
+  hardhat@3.6.0:
     dependencies:
-      '@nomicfoundation/edr': 0.12.0-next.32
+      '@nomicfoundation/edr': 0.12.0-next.33
       '@nomicfoundation/hardhat-errors': 3.0.16
       '@nomicfoundation/hardhat-utils': 4.1.4
       '@nomicfoundation/hardhat-vendored': 3.0.4

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,22 +1,17 @@
-import { defineConfig } from 'vitest/config';
+import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['packages/**/*.test.ts', 'packages/**/*.test.tsx'],
-    exclude: ['node_modules', '**/node_modules', 'dist', '**/*.d.ts', '.next', 'out', '.vitepress'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: [
-        'node_modules/',
-        'dist/',
-        '**/*.test.ts',
-        '**/*.test.tsx',
-        '**/*.d.ts',
-        '**/dist/**',
-      ],
-    },
-  },
+	test: {
+		// Every package holding tests owns a `vitest.config.ts` declaring them, and is
+		//  picked up here as a project. Running `pnpm test` from the root and running
+		//  `pnpm test` from a package therefore run the exact same setup, instead of
+		//  the root config being the only place where test files are declared (which
+		//  made the per-package `test` scripts find no test file at all).
+		projects: ['packages/*/vitest.config.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.test.tsx', '**/*.d.ts', '**/dist/**'],
+		},
+	},
 });


### PR DESCRIPTION
## The bug

`hardhat --network <network> deploy` recompiled with the `production` profile, but deployed the bytecode of the **last full build** (usually `default`, optimizer off).

Typed artifact generation was hooked on `onCleanUpArtifacts`, which hardhat only triggers when a build performs an artifact cleanup, i.e. for a *full* build (`files.length === 0 && !noTests && !noContracts`). The `deploy` task builds with `noTests: true`, so the hook never fired during a deployment. Solidity was recompiled and `artifacts/` was fresh, but `generated/artifacts/*.ts`, which the deployment scripts actually import, kept the previous content.

Observed in a downstream project: the deterministic implementation address changed from `0x140F29e4…` (unoptimized) to `0x785881911…` (optimized) once generation ran at the right time, on the same sources.

## The fix

Generate from `processArtifactsAfterSuccessfulBuild`, which hardhat triggers after every successful `contracts` build, and stop registering the deprecated `onCleanUpArtifacts`.

That hook was introduced in hardhat `3.6.0` (`3.5.1` does not have it), hence:

- `peerDependencies.hardhat`: `^3.4.5` → `^3.6.0`
- `templates/basic`: `hardhat` `^3.1.5` → `^3.6.0`, since `hardhat-deploy init` scaffolds it and any resolution below `3.6.0` would silently reproduce the bug

Ordering is safe because deploy scripts are imported lazily, after the build (`@rocketh/node` executor does `await import()` per script), so the freshly written files are the ones that get loaded.

## Tests

New unit tests drive the handler with hardhat doubles over a real artifacts-folder fixture. Checked they are not vacuous by running them against four implementations:

| implementation | result |
|---|---|
| before this PR | 7 of 7 fail |
| generation skipped when `cleanupArtifacts` is true | 3 fail |
| this PR | 7 pass |

## Also in this PR

The per-package `test` scripts never ran anything: vitest run from a package directory picked up the root config, whose `include` (`packages/**/*.test.ts`) matches nothing relative to a package. Each package holding tests now owns a `vitest.config.ts` and the root collects them as projects, so both entry points run the same setup. `rocketh-node` and `rocketh-verifier` had tests but no script and no devDependency. `pnpm test:coverage` failed on a missing `@vitest/coverage-v8`, now added, with its report directory ignored.

Root run: 13 files, 170 tests. Per-package runs sum to the same 170.

`dorfl verify` passes locally.