### PR TITLE
fix: robust genesis fingerprint and fail-safe handling of genesis-hash mismatches

### DIFF
--- a/packages/rocketh/src/environment/index.ts
+++ b/packages/rocketh/src/environment/index.ts
@@ -226,11 +226,28 @@ export async function createEnvironment<
 	const chainId = '' + Number(chainIdHex);
 	let genesisHash: `0x${string}` | undefined;
 	try {
-		let genesisBlock: EIP1193Block | EIP1193BlockWithTransactions | null;
-		try {
+		// `eth_getBlockByNumber("earliest")` is node-relative, not chain-canonical:
+		// a pruned node returns the oldest block it retained, not block 0. Behind a
+		// load-balanced RPC endpoint this makes the genesis fingerprint
+		// non-deterministic, which can wrongly flag the deployment folder as
+		// belonging to a different chain. Ask for block 0x0 explicitly (validating
+		// the response really is block 0, and retrying in case a balancer rotates
+		// through a pruned backend), and only fall back to "earliest" when no
+		// backend can serve block 0 at all.
+		let genesisBlock: EIP1193Block | EIP1193BlockWithTransactions | null = null;
+		for (let attempt = 0; attempt < 10 && !genesisBlock; attempt++) {
+			try {
+				genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['0x0', false]});
+				if (genesisBlock && genesisBlock.number != null && Number(genesisBlock.number) !== 0) {
+					genesisBlock = null;
+				}
+			} catch {}
+			if (!genesisBlock && attempt < 9) {
+				await wait(0.5);
+			}
+		}
+		if (!genesisBlock) {
 			genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['earliest', false]});
-		} catch {
-			genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['0x0', false]});
 		}
 
 		if (!genesisBlock) {
@@ -1032,7 +1049,12 @@ export async function createEnvironment<
 				: {
 						chainId,
 						genesisHash,
-						deleteDeploymentsIfDifferentGenesisHash: true,
+						// Auto-deleting on a genesis mismatch is only safe for throwaway
+						// dev chains whose genesis rotates on every restart. On live
+						// networks a transient RPC glitch (e.g. a pruned node behind a
+						// load balancer misreporting the genesis) must fail loudly
+						// instead of silently wiping the deployment history.
+						deleteDeploymentsIfDifferentGenesisHash: chainId === '31337' || chainId === '1337',
 					},
 		);
 


### PR DESCRIPTION
## Problem

`createEnvironment` fingerprints the connected chain with `eth_getBlockByNumber("earliest")` and treats the returned hash as the genesis hash. But `"earliest"` is **node-relative, not chain-canonical**: a pruned node returns the oldest block it *retained*, not block 0. Behind a load-balanced RPC endpoint, the fingerprint becomes non-deterministic.

When the misreported hash doesn't match the stored `.chain` genesisHash, `loadDeployments` — called with the hardcoded `deleteDeploymentsIfDifferentGenesisHash: true` — **silently deletes the entire deployments folder** and returns empty, triggering a full redeploy.

## What happened to us

During a live Sepolia deployment (ensdomains/contracts-v2), our RPC (`lb.drpc.live`, a load balancer) routed ~25% of requests to a backend pruned below block 1,000,000. A `--resume`-style run received block 1,000,000's hash as its "genesis" (`0xaad11ee5…` instead of Sepolia's `0x25a5cc10…`), concluded the folder belonged to a different chain, deleted 40 deployment artifacts, and began redeploying the full stack on live Sepolia before we caught it. Recovering required reconstructing every artifact from its creation transaction.

Standalone repro of the fingerprint issue: `cast block earliest --field hash` against a pruned node returns the prune point's hash, not genesis.

## Changes

1. **Fingerprint with an explicit `eth_getBlockByNumber("0x0")` request**, validate the returned block really is block 0, and retry briefly (10 × 500ms) so a balancer rotating through a pruned backend still converges. Fall back to `"earliest"` only when no backend serves block 0 at all. A pruned node errors or returns null for `0x0` — it cannot return a plausible wrong answer the way `"earliest"` can.

2. **Scope the auto-delete to throwaway dev chains** (chainId 31337/1337), whose genesis rotates on every restart — the legitimate reason this behavior exists. On all other chains a genesis mismatch now throws (the error branch already existed), so a transient RPC glitch can no longer wipe live-network deployment history.

We've been running exactly these two changes via `patchedDependencies` in ensdomains/contracts-v2 since the incident, including through a completed Sepolia migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)