### PR TITLE
fix(rocketh): stop wiping deployments on pruned nodes; configurable g…

### DIFF
--- a/.changeset/genesis-hash-pruning-fix.md
+++ b/.changeset/genesis-hash-pruning-fix.md
@@ -1,0 +1,12 @@
+---
+'@rocketh/core': patch
+'rocketh': minor
+---
+
+Fix spurious deployment wipes caused by using the `"earliest"` block tag as the genesis fingerprint.
+
+rocketh fetched the chain's genesis hash via `eth_getBlockByNumber("earliest")`. On pruned nodes `"earliest"` does not return genesis — geth resolves it to `HistoryPruningCutoff()` and reth to `earliest_block_number()`, i.e. the prune-cutoff block whose hash is not the genesis hash and drifts as history is pruned. The recorded `.chain` genesisHash therefore stopped matching, and because `deleteDeploymentsIfDifferentGenesisHash` was hardcoded `true` for every non-fork environment, rocketh silently deleted the entire deployments folder on real chains whenever the node pruned (or two nodes pruned to different points).
+
+Genesis is now fetched explicitly via block number `0x0`. On a pruned node that throws (geth `PrunedHistoryError` / reth `PrunedHistoryUnavailable`) or returns null, the genesis hash is left undefined and the mismatch check is skipped entirely — no delete, no throw. Dev/full nodes (never pruned) keep returning the real genesis, so reset detection still works there.
+
+The delete-on-mismatch behavior is now configurable via a new chain config option `deleteDeploymentsIfDifferentGenesisHash` (resolved like `autoMine`/`autoImpersonate`), using `??` so an explicit `false` on a default-`true` chain actually opts out (`||` would have silently ignored the opt-out). It defaults to `true` for the recognised dev chain ids 1337 and 31337 (reset detection out of the box) and `false` everywhere else. Non-dev chains now throw with a clear reason on a genesis mismatch instead of silently wiping — the message explains how to mark a resettable chain (set the option to `true`) or recover a stale `.chain` (remove its `genesisHash` field, e.g. left over from the old `"earliest"` behavior). The option also inherits per-environment `overrides` for free.

--- a/packages/rocketh-core/src/types.ts
+++ b/packages/rocketh-core/src/types.ts
@@ -242,6 +242,14 @@ export type ChainUserConfig = {
 	readonly autoImpersonate?: boolean;
 	readonly autoMine?: boolean;
 	readonly confirmationsRequired?: number;
+	/**
+	 * If true, rocketh auto-deletes the deployments folder when the recorded
+	 * genesisHash no longer matches the chain's genesis. Intended for
+	 * ephemeral/dev chains that get reset. Defaults to true for the recognised
+	 * dev chain ids (1337, 31337); override with `false` to opt out, or `true`
+	 * to enable on a custom dev chain.
+	 */
+	readonly deleteDeploymentsIfDifferentGenesisHash?: boolean;
 };
 
 export type ChainConfig = {
@@ -253,6 +261,7 @@ export type ChainConfig = {
 	readonly autoImpersonate: boolean;
 	readonly autoMine: boolean;
 	readonly confirmationsRequired?: number;
+	readonly deleteDeploymentsIfDifferentGenesisHash: boolean;
 } & (
 	| {
 			readonly rpcUrl: string;
@@ -559,6 +568,7 @@ export type ResolvedExecutionParams<Extra extends Record<string, unknown> = Reco
 		readonly autoImpersonate?: boolean;
 		readonly confirmationsRequired?: number;
 		readonly autoMine: boolean;
+		readonly deleteDeploymentsIfDifferentGenesisHash: boolean;
 	};
 	readonly chain: ChainInfo;
 	readonly tags: readonly string[];

--- a/packages/rocketh/package.json
+++ b/packages/rocketh/package.json
@@ -63,6 +63,7 @@
 		"prepublishOnly": "cp ../../README.md README.md && cp ../../LICENSE LICENSE",
 		"show-chains-with-same-chainId": "tsx show-chains-with-same-chainId.ts",
 		"build": "tsc --project tsconfig.json",
-		"dev": "as-soon -w src pnpm build"
+		"dev": "as-soon -w src pnpm build",
+		"test": "vitest"
 	}
 }

--- a/packages/rocketh/src/environment/chains.ts
+++ b/packages/rocketh/src/environment/chains.ts
@@ -7,6 +7,9 @@ import {
 	ResolvedUserConfig,
 } from '../types.js';
 
+/** Chain ids that are considered ephemeral/dev (resettable) by convention. */
+const KNOWN_DEV_CHAIN_IDS = new Set([1337, 31337]);
+
 export function getChainConfigFromUserConfig(
 	config: ResolvedUserConfig,
 	id: number,
@@ -95,6 +98,8 @@ export function getChainConfigFromUserConfig(
 			autoImpersonate: chainConfig?.autoImpersonate || false,
 			autoMine: chainConfig?.autoMine || false,
 			confirmationsRequired: chainConfig?.confirmationsRequired,
+			deleteDeploymentsIfDifferentGenesisHash:
+				chainConfig?.deleteDeploymentsIfDifferentGenesisHash ?? KNOWN_DEV_CHAIN_IDS.has(id),
 		};
 	} else if (rpcUrl) {
 		return {
@@ -107,6 +112,8 @@ export function getChainConfigFromUserConfig(
 			autoImpersonate: chainConfig?.autoImpersonate || false,
 			autoMine: chainConfig?.autoMine || false,
 			confirmationsRequired: chainConfig?.confirmationsRequired,
+			deleteDeploymentsIfDifferentGenesisHash:
+				chainConfig?.deleteDeploymentsIfDifferentGenesisHash ?? KNOWN_DEV_CHAIN_IDS.has(id),
 		};
 	} else {
 		throw new Error(`chain with id ${id} has no rpc url provided nor any provider to use`);

--- a/packages/rocketh/src/environment/index.ts
+++ b/packages/rocketh/src/environment/index.ts
@@ -27,8 +27,6 @@ import {InternalEnvironment} from '../internal/types.js';
 import {JSONToString, stringToJSON} from '@rocketh/core/json';
 import {
 	EIP1193Account,
-	EIP1193Block,
-	EIP1193BlockWithTransactions,
 	EIP1193DATA,
 	EIP1193ProviderWithoutEvents,
 	EIP1193Transaction,
@@ -157,7 +155,13 @@ export async function loadDeploymentsFromStore(
 						return {deployments: {}, migrations: {}};
 					} else {
 						throw new Error(
-							`Loading deployment from environment '${networkName}' (with genesisHash: ${genesisHash}) for a different genesisHash (${expectedChain.genesisHash})`,
+							`Deployment folder for environment '${networkName}' was recorded with genesisHash ${genesisHash}, ` +
+								`but the current chain's genesisHash is ${expectedChain.genesisHash}.\n` +
+								`This usually means the chain was reset. If '${networkName}' is an ephemeral/dev chain ` +
+								`(resettable), set deleteDeploymentsIfDifferentGenesisHash: true on its chain config ` +
+								`so rocketh auto-deletes the stale deployments. If this is a real chain and the ` +
+								`stored value is stale (e.g. from an older rocketh version that used the ` +
+								`"earliest" block), remove the "genesisHash" field from the .chain file.`,
 						);
 					}
 				}
@@ -226,20 +230,23 @@ export async function createEnvironment<
 	const chainId = '' + Number(chainIdHex);
 	let genesisHash: `0x${string}` | undefined;
 	try {
-		let genesisBlock: EIP1193Block | EIP1193BlockWithTransactions | null;
-		try {
-			genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['earliest', false]});
-		} catch {
-			genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['0x0', false]});
+		// Fetch genesis explicitly via block number 0. We deliberately do NOT use
+		// the "earliest" tag: on pruned nodes "earliest" returns the prune-cutoff
+		// block (whose hash is not the genesis hash and is unstable across
+		// nodes/prune operations), which would cause spurious genesis-mismatch
+		// detection. On a pruned node `0x0` throws (geth PrunedHistoryError /
+		// reth PrunedHistoryUnavailable) or returns null; in that case we leave
+		// genesisHash undefined and the mismatch check is skipped entirely.
+		const genesisBlock = await provider.request({method: 'eth_getBlockByNumber', params: ['0x0', false]});
+		if (genesisBlock && Number(genesisBlock.number) === 0) {
+			genesisHash = genesisBlock.hash as `0x${string}`;
+		} else if (genesisBlock) {
+			console.warn(
+				`Block fetched for '0x0' is not genesis (number: ${Number(genesisBlock.number)}); ignoring as genesis fingerprint.`,
+			);
 		}
-
-		if (!genesisBlock) {
-			console.error(`failed to get genesis block, returned null`);
-		}
-
-		genesisHash = genesisBlock?.hash;
-	} catch (err) {
-		console.error(`failed to get genesis block`);
+	} catch {
+		// genesis unavailable (e.g. pruned node) — no genesis fingerprint
 	}
 
 	const deploymentsFolder = userConfig.deployments;
@@ -381,6 +388,8 @@ export async function createEnvironment<
 		saveDeployments,
 		tags: networkTags,
 		autoMine: resolvedExecutionParams.environment.autoMine,
+		deleteDeploymentsIfDifferentGenesisHash:
+			resolvedExecutionParams.environment.deleteDeploymentsIfDifferentGenesisHash,
 	};
 
 	const deployments: UnknownDeployments = {};
@@ -1032,7 +1041,7 @@ export async function createEnvironment<
 				: {
 						chainId,
 						genesisHash,
-						deleteDeploymentsIfDifferentGenesisHash: true,
+						deleteDeploymentsIfDifferentGenesisHash: context.deleteDeploymentsIfDifferentGenesisHash,
 					},
 		);
 

--- a/packages/rocketh/src/executor/index.ts
+++ b/packages/rocketh/src/executor/index.ts
@@ -280,6 +280,7 @@ export function resolveExecutionParams<Extra extends Record<string, unknown> = R
 			autoImpersonate,
 			confirmationsRequired: actualChainConfig.confirmationsRequired,
 			autoMine,
+			deleteDeploymentsIfDifferentGenesisHash: actualChainConfig.deleteDeploymentsIfDifferentGenesisHash,
 		},
 		extra: executionParameters.extra,
 		provider,

--- a/packages/rocketh/test/chains.test.ts
+++ b/packages/rocketh/test/chains.test.ts
@@ -1,0 +1,87 @@
+import {describe, it, expect} from 'vitest';
+
+import {getChainConfigFromUserConfig} from '../src/environment/chains.js';
+import type {ChainInfo, ChainUserConfig, ResolvedUserConfig} from '@rocketh/core/types';
+
+/** Minimal chain info for tests. */
+function chainInfo(id: number, testnet = false): ChainInfo {
+	return {
+		id,
+		name: 'test',
+		nativeCurrency: {name: 'Ether', symbol: 'ETH', decimals: 18},
+		rpcUrls: {default: {http: []}},
+		chainType: 'default',
+		testnet,
+	};
+}
+
+/** Minimal resolved user config carrying only a `chains` map (enough for getChainConfigFromUserConfig). */
+function makeConfig(chains: Record<number, ChainUserConfig>): ResolvedUserConfig {
+	return {
+		retry: {maxRetries: 3, delay: 1000},
+		deployments: 'deployments',
+		scripts: ['deploy'],
+		defaultPollingInterval: 1000,
+		chains,
+	};
+}
+
+function chainConfig(id: number, overrides: Partial<ChainUserConfig> = {}): ChainUserConfig {
+	return {rpcUrl: 'http://localhost:8545', info: chainInfo(id), ...overrides};
+}
+
+describe('getChainConfigFromUserConfig - deleteDeploymentsIfDifferentGenesisHash', () => {
+	/**
+	 * Dev chain ids (hardhat/anvil/foundry = 31337, localhost/tempoLocalnet = 1337) default to
+	 * `true` so reset detection (auto-delete stale deployments) works out of the box.
+	 */
+	it('defaults to true for dev chain id 31337', () => {
+		const cfg = getChainConfigFromUserConfig(makeConfig({31337: chainConfig(31337)}), 31337);
+		expect(cfg.deleteDeploymentsIfDifferentGenesisHash).toBe(true);
+	});
+
+	it('defaults to true for dev chain id 1337', () => {
+		const cfg = getChainConfigFromUserConfig(makeConfig({1337: chainConfig(1337)}), 1337);
+		expect(cfg.deleteDeploymentsIfDifferentGenesisHash).toBe(true);
+	});
+
+	/**
+	 * Real chains (e.g. mainnet = 1) default to `false`: a genesis mismatch there is treated as an
+	 * error (throw), never a silent wipe.
+	 */
+	it('defaults to false for a non-dev chain id (1)', () => {
+		const cfg = getChainConfigFromUserConfig(makeConfig({1: chainConfig(1)}), 1);
+		expect(cfg.deleteDeploymentsIfDifferentGenesisHash).toBe(false);
+	});
+
+	/**
+	 * The default is `true` for dev chains, so the field MUST be resolved with `??` (not `||`).
+	 * With `||`, an explicit `false` on a 31337 chain would be `false || true === true` and the
+	 * opt-out would be silently ignored. This test pins the `??` behaviour.
+	 */
+	it('allows opting out (false) on a 31337 chain (uses ??, not ||)', () => {
+		const cfg = getChainConfigFromUserConfig(
+			makeConfig({31337: chainConfig(31337, {deleteDeploymentsIfDifferentGenesisHash: false})}),
+			31337,
+		);
+		expect(cfg.deleteDeploymentsIfDifferentGenesisHash).toBe(false);
+	});
+
+	it('allows opting in (true) on a non-dev chain', () => {
+		const cfg = getChainConfigFromUserConfig(
+			makeConfig({1: chainConfig(1, {deleteDeploymentsIfDifferentGenesisHash: true})}),
+			1,
+		);
+		expect(cfg.deleteDeploymentsIfDifferentGenesisHash).toBe(true);
+	});
+
+	/**
+	 * The mechanism is a chain config option, not a tag. Confirm no `ephemeral` tag is injected
+	 * for dev chains (regression guard against the earlier tag-based design).
+	 */
+	it('does NOT add an "ephemeral" tag for dev chains', () => {
+		const cfg = getChainConfigFromUserConfig(makeConfig({31337: chainConfig(31337)}), 31337);
+		expect([...cfg.tags]).not.toContain('ephemeral');
+		expect([...cfg.tags]).toEqual([]);
+	});
+});

--- a/packages/rocketh/test/loadDeploymentsFromStore.test.ts
+++ b/packages/rocketh/test/loadDeploymentsFromStore.test.ts
@@ -1,0 +1,146 @@
+import {describe, it, expect, vi} from 'vitest';
+
+import {loadDeploymentsFromStore} from '../src/environment/index.js';
+import type {DeploymentStore} from '@rocketh/core/types';
+
+/**
+ * In-memory DeploymentStore for tests. The same record is mutated by deleteAll/write/deleteFile
+ * so tests can assert side effects.
+ */
+function makeStore(initial: Record<string, string>): {store: DeploymentStore; files: Record<string, string>} {
+	const files: Record<string, string> = {...initial};
+	const store: DeploymentStore = {
+		listFiles: vi.fn(async (_folder, _env, filter) =>
+			Object.keys(files).filter((name) => (filter ? filter(name) : true)),
+		),
+		deleteAll: vi.fn(async () => {
+			for (const key of Object.keys(files)) delete files[key];
+		}),
+		hasFile: vi.fn(async (_folder, _env, name) => files[name] !== undefined),
+		writeFile: vi.fn(async (_folder, _env, name, content) => {
+			files[name] = content;
+		}),
+		writeFileWithChainInfo: vi.fn(async (_info, _folder, _env, name, content) => {
+			files[name] = content;
+		}),
+		readFile: vi.fn(async (_folder, _env, name) => files[name]),
+		deleteFile: vi.fn(async (_folder, _env, name) => {
+			delete files[name];
+		}),
+	};
+	return {store, files};
+}
+
+const STORED = '0x111111111111111111111111111111111111111111111111111111111111aaaa';
+const EXPECTED = '0x222222222222222222222222222222222222222222222222222222222222bbbb';
+
+function chainFile(chainId: string, genesisHash?: string): string {
+	return JSON.stringify({chainId, genesisHash});
+}
+
+const DEPLOYMENT_FILE = JSON.stringify({address: '0xabc0000000000000000000000000000000000000', abi: []});
+
+function filesWith(chainFileContent: string): Record<string, string> {
+	return {'.chain': chainFileContent, 'MyContract.json': DEPLOYMENT_FILE};
+}
+
+describe('loadDeploymentsFromStore - genesis hash mismatch policy', () => {
+	/**
+	 * Ephemeral/dev chain (deleteDeploymentsIfDifferentGenesisHash: true): a recorded genesisHash
+	 * that no longer matches means the chain was reset → auto-delete the stale deployments.
+	 */
+	it('deletes all deployments when genesisHash differs and delete flag is true', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		const result = await loadDeploymentsFromStore(store, 'deployments', 'dev', false, {
+			chainId: '1',
+			genesisHash: EXPECTED,
+			deleteDeploymentsIfDifferentGenesisHash: true,
+		});
+		expect(store.deleteAll).toHaveBeenCalledTimes(1);
+		expect(result.deployments).toEqual({});
+		expect(result.migrations).toEqual({});
+	});
+
+	/**
+	 * Real chain (deleteDeploymentsIfDifferentGenesisHash: false / unset): a genesis mismatch is an
+	 * error, never a silent wipe. rocketh must abort with a clear reason.
+	 */
+	it('throws (and does NOT delete) when genesisHash differs and delete flag is false', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		await expect(
+			loadDeploymentsFromStore(store, 'deployments', 'mainnet', false, {
+				chainId: '1',
+				genesisHash: EXPECTED,
+				deleteDeploymentsIfDifferentGenesisHash: false,
+			}),
+		).rejects.toThrow(/genesisHash/);
+		expect(store.deleteAll).not.toHaveBeenCalled();
+	});
+
+	it('throws by default when the delete flag is unset (non-dev default)', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		await expect(
+			loadDeploymentsFromStore(store, 'deployments', 'mainnet', false, {
+				chainId: '1',
+				genesisHash: EXPECTED,
+			}),
+		).rejects.toThrow(/genesisHash/);
+		expect(store.deleteAll).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Pruned node case: the current chain's genesis could not be fetched (genesisHash undefined),
+	 * so the mismatch check is skipped entirely. Existing deployments are preserved — no delete,
+	 * no throw. This is the fix for the "earliest" bug causing spurious wipes on pruned nodes.
+	 */
+	it('skips the check (no delete, no throw) when the expected genesisHash is undefined', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		const result = await loadDeploymentsFromStore(store, 'deployments', 'mainnet', false, {
+			chainId: '1',
+			genesisHash: undefined,
+			deleteDeploymentsIfDifferentGenesisHash: false,
+		});
+		expect(store.deleteAll).not.toHaveBeenCalled();
+		expect(result.genesisHash).toBe(STORED);
+		expect(result.deployments.MyContract).toBeDefined();
+		expect((result.deployments.MyContract as {address: string}).address).toBe(
+			'0xabc0000000000000000000000000000000000000',
+		);
+	});
+
+	it('loads deployments unchanged when genesisHash matches (no delete, no throw)', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		const result = await loadDeploymentsFromStore(store, 'deployments', 'mainnet', false, {
+			chainId: '1',
+			genesisHash: STORED,
+			deleteDeploymentsIfDifferentGenesisHash: false,
+		});
+		expect(store.deleteAll).not.toHaveBeenCalled();
+		expect(result.deployments.MyContract).toBeDefined();
+	});
+
+	/**
+	 * Forks pass `expectedChain = undefined`, so no mismatch check runs at all.
+	 */
+	it('skips the check entirely when expectedChain is undefined (fork case)', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		const result = await loadDeploymentsFromStore(store, 'deployments', 'fork', false, undefined);
+		expect(store.deleteAll).not.toHaveBeenCalled();
+		expect(result.deployments.MyContract).toBeDefined();
+	});
+
+	/**
+	 * Regression guard: a chainId mismatch is still a hard error regardless of the genesis policy.
+	 */
+	it('throws on chainId mismatch regardless of the delete flag', async () => {
+		const {store} = makeStore(filesWith(chainFile('1', STORED)));
+		await expect(
+			loadDeploymentsFromStore(store, 'deployments', 'mainnet', false, {
+				chainId: '2',
+				genesisHash: STORED,
+				deleteDeploymentsIfDifferentGenesisHash: true,
+			}),
+		).rejects.toThrow(/chainId/);
+		expect(store.deleteAll).not.toHaveBeenCalled();
+	});
+});

--- a/packages/rocketh/vitest.config.ts
+++ b/packages/rocketh/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+	},
+});


### PR DESCRIPTION
…enesis-mismatch policy

The "earliest" block tag was used as the genesis hash fingerprint, but on pruned nodes it resolves to the prune-cutoff block (geth HistoryPruningCutoff / reth earliest_block_number), not genesis. Its hash is not the genesis hash and drifts as history is pruned, so the recorded .chain genesisHash stopped matching and rocketh silently deleted the whole deployments folder on real chains.

- Fetch genesis via block number 0x0 only; on pruned nodes leave genesisHash undefined and skip the mismatch check (no delete, no throw). Dev/full nodes keep returning the real genesis, so reset detection still works.
- Replace the hardcoded delete-on-mismatch with a chain config option deleteDeploymentsIfDifferentGenesisHash (resolved like autoMine), using ?? so an explicit false on a default-true chain opts out. Defaults to true for dev chain ids 1337/31337, false elsewhere. Non-dev chains now throw with a clear reason instead of silently wiping. Inherits per-environment overrides.
- Add tests for the ?? opt-out and the delete/throw/no-op policy.

Adds @rocketh/core type fields (ChainUserConfig/ChainConfig/ResolvedExecutionParams).