### PR TITLE
test(export): pin a 60s timeout on the tsc-compiling suite

### DIFF
--- a/.changeset/pin-export-typecheck-suite-timeout.md
+++ b/.changeset/pin-export-typecheck-suite-timeout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin a 60s timeout on the four `@rocketh/export` tests that compile the generated TypeScript with tsc, which are the heaviest tests in the monorepo and were inheriting vitest's 5s default. Idle they take about a second each, but under the repo-wide `pnpm test` they compete with 90-odd other test files immediately after a full build and have been measured at 6186ms and 6670ms, so they timed out and failed acceptance gates for tasks that never touched this package (six times in one six-task drive). The budget is pinned on the suite that earns it rather than raised globally, so every other test keeps the 5s default. Test-only change; no package code and no behaviour changes.

--- a/packages/rocketh-export/test/export.test.ts
+++ b/packages/rocketh-export/test/export.test.ts
@@ -490,7 +490,24 @@ describe('@rocketh/export - CLI exit code and streams', () => {
  * `readonly []`, a type that accepts nothing, so injecting an RPC endpoint at run time did not
  * compile. Every consumer had to discover and re-solve that.
  */
-describe('@rocketh/export - the generated TypeScript compiles for real consumers', () => {
+/**
+ * These four are the heaviest tests in the monorepo: each one COMPILES the generated TypeScript
+ * with tsc in a spawned process, which is CPU-bound and orders of magnitude heavier than the
+ * assertion-only tests around it. Idle they take about a second each; under the repo-wide
+ * `pnpm test`, where they compete with 90-odd other test files immediately after a full build,
+ * they have been measured at 6186ms and 6670ms and so overshoot vitest's 5s default.
+ *
+ * That made them bounce acceptance gates for tasks that never touched this package, six times in
+ * one six-task drive alone, and the first reading is always "did my change break export?". The
+ * cost is INHERENT and known rather than accidental, so the budget is pinned here, on the suite
+ * that earns it, rather than by raising the global default (which is doing useful work for every
+ * other test) or by reducing the parallelism around it.
+ *
+ * Generous on purpose: at roughly a second when idle, this is not a threshold these tests can
+ * approach except when something is genuinely wrong, and it still bounds a hung compiler.
+ * See `work/notes/observations/export-typecheck-tests-flake-under-load-on-the-default-5s-timeout.md`.
+ */
+describe('@rocketh/export - the generated TypeScript compiles for real consumers', {timeout: 60_000}, () => {
 	/**
 	 * Resolved from THIS FILE, never from `process.cwd()`.
 	 *


### PR DESCRIPTION
The four tests in `@rocketh/export - the generated TypeScript compiles for real consumers` each compile the generated output with `tsc` in a spawned process. They are the heaviest tests in the monorepo and were inheriting vitest's 5s default.

Idle they take about a second each. Under the repo-wide `pnpm test`, where they compete with 90-odd other test files immediately after a full build, they have been measured at **6186ms and 6670ms**, so they timed out and failed acceptance gates for tasks that never touched this package: **six times in one six-task drive**, each bounce costing a full re-verification cycle to distinguish from a real red. The first reading is always "did my change break export?".

### Why this shape

The cost is inherent and known rather than accidental, so the budget is pinned on the suite that earns it:

- **Not the global default**, which is doing useful work for every other test.
- **Not reduced parallelism**, which would slow the whole suite to accommodate four tests.
- **Not moving them out of the default suite**, which would cost them their place in the gate.

Scoping verified by reading back the resolved timeouts rather than assuming: a test inside the suite reports `60000`, a sibling suite still reports `5000`. So the other 31 tests in this file, and every other test in the repo, are unaffected.

60s is generous on purpose. At roughly a second when idle, this is not a threshold these tests can approach unless something is genuinely wrong, and it still bounds a hung compiler.

### Verification

Full configured chain, green end to end: `format:check`, `sync:template:check`, `changeset status`, `build`, `typecheck`, `test` (**95/95 files, 1102/1102 tests**) and `test:getting-started`. That is the first fully green repo-wide run in a while, since the flake had been failing it every time.

Test-only change; no package code, no behaviour change, empty changeset. Background: `work/notes/observations/export-typecheck-tests-flake-under-load-on-the-default-5s-timeout.md`.
