### PR TITLE
fix(rocketh): a fork must not inherit the simulated network's endpoint

### DIFF
--- a/.changeset/fork-does-not-inherit-the-simulated-network-endpoint.md
+++ b/.changeset/fork-does-not-inherit-the-simulated-network-endpoint.md
@@ -1,0 +1,5 @@
+---
+'rocketh': patch
+---
+
+A fork run no longer inherits `environments[<name>].overrides.rpcUrl`, which on the environment of a real network is that network's own endpoint. Inheriting it pointed a fork run at production while the user believed they were on their fork, silently, with the deployment records and every impersonated step landing against the real chain. On a fork the endpoint now comes from `whenForked.rpcUrl`, else the conventional local endpoint; every other field in the `overrides` bag still crosses, so a fork keeps being configured like the network it simulates, and a NON-fork run of the same environment still dials the endpoint its overrides name. This is the same rule that already kept `chains[<forked id>]` from supplying the connection, applied one layer higher: connection from the local side, everything else from the network being simulated. The hazard was latent rather than live, since the only caller able to fork today always passes a `provider`, which beats any `rpcUrl` in the merge; it would have become reachable on the planned `--is-fork` path.

--- a/docs/adr/0014-a-fork-run-simulates-one-chain-and-talks-to-another.md
+++ b/docs/adr/0014-a-fork-run-simulates-one-chain-and-talks-to-another.md
@@ -39,6 +39,16 @@ That also leaves the two verbs able to coexist honestly later: `--is-fork` attac
 
 This is the second naming correction of the same shape in this decision, after `whenForked` (which was `fork`), and the repetition is the useful part: **in this domain the bare word `fork` is ambiguous across three parts of speech** — the noun (a forked node), the adjective (this run is against one) and the verb (create one). Every name that uses it should be explicit about which it means, because the verb reading is the one that silently promises a capability.
 
+## Refinement: the `overrides` layer lends a fork everything EXCEPT its endpoint
+
+The layering above is stated as `chains[<forked id>]` under `environments[<name>].overrides` under `environments[<name>].whenForked`, most specific last. That is right for every field but one, and the exception was found by building it: `overrides` belongs to the environment of a REAL network, so its `rpcUrl` is **that network's own endpoint**. A fork run inheriting it dials production while the user believes they are on their fork, and does so silently, with the deployment records and every impersonated Safe step landing against the real chain. It is the same failure the `chains[31337]` correction above prevents, arriving one layer higher.
+
+So on a fork the endpoint is **withheld** from the `overrides` layer, and comes from `whenForked.rpcUrl` else the conventional local endpoint. Every other field in that same bag still crosses, so a fork keeps being configured like the network it simulates.
+
+This is not an exception to the model, it IS the model: connection from the LOCAL side, everything else from the network being SIMULATED. The endpoint is the connection, and the connection may not be inherited from the simulated network at ANY layer, which is exactly why `chains[<forked id>]` never supplied it either. Writing `whenForked: {rpcUrl}` was already the documented remedy, but a remedy nobody knows they need is not a defence: same reasoning as `whenForked`'s own naming, prefer making the mistake unrepresentable over documenting the pairing.
+
+The hazard was latent rather than live when it was closed, because the only caller that could fork (hardhat-deploy) always passes a `provider`, which beats any `rpcUrl` in the merge. It becomes reachable on the `--is-fork` path, which is precisely the path that attaches to an anvil fork with no provider of its own, so it was closed before that path exists rather than after.
+
 ## Consequences
 
 - **`chains[31337]` stops being the fork run's configuration.** It is where a user configures their LOCAL DEV NODE, and all of it, tags included, was silently becoming the configuration of a fork of mainnet. Deploy scripts branch on tags, so a script taking a shortcut under a `local` tag was taking it during what the user believed was a mainnet rehearsal. That is worse than absent configuration, because it is different configuration actively applied.

--- a/packages/rocketh/src/executor/index.ts
+++ b/packages/rocketh/src/executor/index.ts
@@ -331,13 +331,28 @@ export function resolveExecutionParams<Extra extends Record<string, unknown> = R
 		connectedChainConfig.info.id === chainId ? connectedChainConfig.info : {...connectedChainConfig.info, id: chainId};
 	// The environment-level override layer already ran on fork runs, since the environment NAME is
 	// the forked network's. It sits ON TOP of both buckets, so a user's overrides keep winning.
-	const overriddenChainConfig = environmentConfig?.overrides
+	//
+	// ...with ONE field withheld on a fork, and it is the dangerous one. `overrides` belongs to the
+	// environment of a REAL network, so its `rpcUrl` is that network's own endpoint: the single
+	// address a rehearsal must never dial. Inheriting it would point a fork run at production while
+	// the user believed they were on their fork, which is the worst outcome this file can produce,
+	// and it would do so silently. Withholding it is not an exception to the layering but the same
+	// rule that already governs it: connection from the LOCAL side, everything else from the network
+	// being simulated (ADR 0014). `chains[<forked id>]` does not supply the connection either.
+	// Where the fork listens is said by `whenForked.rpcUrl` below, else the conventional local
+	// endpoint. Every other override still crosses, so this costs a fork nothing it should inherit.
+	const connectionOverrides =
+		fork && environmentConfig?.overrides
+			? (({rpcUrl: _theRealNetworksEndpoint, ...rest}) => rest)(environmentConfig.overrides)
+			: environmentConfig?.overrides;
+
+	const overriddenChainConfig = connectionOverrides
 		? {
 				...connectedChainConfig,
-				...environmentConfig.overrides,
+				...connectionOverrides,
 				properties: {
 					...connectedChainConfig?.properties,
-					...environmentConfig.overrides.properties,
+					...connectionOverrides.properties,
 				},
 			}
 		: connectedChainConfig;

--- a/packages/rocketh/test/fork-config-layer.test.ts
+++ b/packages/rocketh/test/fork-config-layer.test.ts
@@ -268,3 +268,84 @@ describe('what this must NOT change', () => {
 		expect(resolved.environment.onUnknownSigner).toBe('ask');
 	});
 });
+
+/**
+ * The one field the `overrides` layer does NOT lend a fork: its endpoint.
+ *
+ * `environments.mainnet.overrides.rpcUrl` is how you reach the REAL mainnet, because that is the
+ * environment it describes. On a fork run it is therefore the single address that must never be
+ * dialled, and inheriting it would put a rehearsal on production silently, with every deployment
+ * record and every impersonated Safe step landing against the real chain.
+ *
+ * It is latent rather than live for today's only forking caller (hardhat-deploy always passes a
+ * `provider`, which beats any `rpcUrl` in the merge), and it becomes reachable on the `--is-fork`
+ * path, which is exactly the path that attaches to an anvil fork with no provider of its own.
+ */
+describe('a fork never inherits the endpoint of the network it simulates', () => {
+	const overridesNameProduction: UserConfig = {
+		...baseConfig,
+		environments: {
+			mainnet: {
+				chain: 1,
+				// how you reach the real mainnet, and on a fork the one address to avoid
+				overrides: {rpcUrl: MAINNET_RPC_URL, tags: ['rehearsal'], confirmationsRequired: 2},
+			},
+		},
+	};
+
+	it('falls back to the conventional local endpoint rather than dialling production', () => {
+		const resolved = resolve({
+			config: overridesNameProduction,
+			environment: {fork: 'mainnet'},
+			computedChainId: 31337,
+		});
+
+		expect(endpointOf(resolved.provider)).toBe(CONVENTIONAL_LOCAL_RPC_URL);
+		expect(endpointOf(resolved.provider)).not.toBe(MAINNET_RPC_URL);
+	});
+
+	/**
+	 * The withholding is scoped to the ENDPOINT. Everything else in the same bag still crosses,
+	 * so a fork keeps being configured like the network it simulates: without this the test above
+	 * would also pass for an implementation that dropped the whole layer on a fork.
+	 */
+	it('still inherits every OTHER override from the same bag', () => {
+		const resolved = resolve({
+			config: overridesNameProduction,
+			environment: {fork: 'mainnet'},
+			computedChainId: 31337,
+		});
+
+		expect(resolved.environment.tags).toEqual(['rehearsal']);
+		expect(resolved.environment.confirmationsRequired).toBe(2);
+	});
+
+	it('lets the fork layer name the endpoint, which is where it belongs', () => {
+		const resolved = resolve({
+			config: {
+				...baseConfig,
+				environments: {
+					mainnet: {chain: 1, overrides: {rpcUrl: MAINNET_RPC_URL}, whenForked: {rpcUrl: FORK_RPC_URL}},
+				},
+			},
+			environment: {fork: 'mainnet'},
+			computedChainId: 31337,
+		});
+
+		expect(endpointOf(resolved.provider)).toBe(FORK_RPC_URL);
+	});
+
+	/**
+	 * And nothing was loosened off a fork: a plain run of the same environment still dials the
+	 * endpoint its overrides name, which is the whole point of declaring one.
+	 */
+	it('leaves a NON-fork run of the same environment dialling its overridden endpoint', () => {
+		const resolved = resolve({
+			config: overridesNameProduction,
+			environment: 'mainnet',
+			computedChainId: 1,
+		});
+
+		expect(endpointOf(resolved.provider)).toBe(MAINNET_RPC_URL);
+	});
+});


### PR DESCRIPTION
Closes the hazard captured during the `fork-of-a-named-network` drive.

`environments[<name>].overrides` describes a **real** network, so its `rpcUrl` is that network's own endpoint. A fork run inherited it, which pointed the run at **production** while the user believed they were on their fork, silently: deployment records and every impersonated Safe step would have landed against the real chain.

### The rule, not an exception to it

On a fork the endpoint is now withheld from the `overrides` layer and comes from `whenForked.rpcUrl`, else the conventional local endpoint. **Every other field in that bag still crosses**, so a fork keeps being configured like the network it simulates.

This is the same rule that already stops `chains[<forked id>]` supplying the connection, applied one layer higher: connection from the LOCAL side, everything else from the network being SIMULATED. The endpoint is the connection, so it may not be inherited from the simulated network at any layer. Writing `whenForked: {rpcUrl}` was already the documented remedy, but a remedy nobody knows they need is not a defence, which is the same reasoning that named `whenForked` in the first place. ADR 0014 records the refinement.

### Latent, and closed before it goes live

hardhat-deploy always passes a `provider`, which beats any `rpcUrl` in the merge, so no shipped caller can hit this today. It becomes reachable on the planned `--is-fork` path, which is exactly the path that attaches to an anvil fork with no provider of its own. Closing it now means that path does not inherit a live trap.

### Tests

Four, and they are discriminating rather than merely present. Verified by reverting the fix and re-running: **exactly the hazard test fails, the other twelve still pass.**

- a fork with `overrides.rpcUrl` naming production dials the conventional local endpoint instead
- it still inherits every OTHER override from the same bag, so an implementation that dropped the whole layer on a fork would fail this
- `whenForked.rpcUrl` still names the endpoint
- a NON-fork run of the same environment still dials its overridden endpoint, so nothing was loosened

Full configured chain green: `format:check`, `sync:template:check`, `changeset status`, `build`, `typecheck`, `test` (95/95 files, **1106/1106** tests) and `test:getting-started`.
