### PR TITLE
docs: a fork never dials overrides.rpcUrl, so stop asking readers to defend against it

### DIFF
--- a/.changeset/fix-fork-docs-overrides-rpcurl.md
+++ b/.changeset/fix-fork-docs-overrides-rpcurl.md
@@ -1,0 +1,4 @@
+---
+---
+
+Correct a stale sentence in the fork-runs page: it told readers to restate the fork's endpoint in `whenForked` because an `overrides.rpcUrl` would otherwise be what a fork dials. A fork run no longer inherits that endpoint at all, so the remedy is unnecessary and the reason given was wrong. Documentation only.

--- a/documentation/fork-runs/index.md
+++ b/documentation/fork-runs/index.md
@@ -146,7 +146,7 @@ environments: {
 }
 ```
 
-Two things worth knowing about that endpoint. It is only consulted when you did not hand rocketh a `provider` (a provider always wins), which is why the hardhat path never touches it. And because the fork layer sits ON TOP of `overrides`, an `overrides.rpcUrl` naming the real network's endpoint would otherwise be what a fork run dials: if your environment entry has one, name the fork's endpoint in `whenForked` as well.
+Two things worth knowing about that endpoint. It is only consulted when you did not hand rocketh a `provider` (a provider always wins), which is why the hardhat path never touches it. And you do not have to defend against your own `overrides`: a fork run never dials `overrides.rpcUrl`, because on the environment of a real network that is the REAL network's endpoint, and a rehearsal pointed at production is the one outcome none of this may produce. Only `whenForked.rpcUrl` and the conventional local endpoint are ever dialled by a fork.
 
 **Declaring `whenForked` does not fork anything.** It says what differs ONCE a run is a fork, and the conditional name is chosen to say so. A plain `-e mainnet` run of an environment carrying the key behaves exactly as though the key were not there.
 

--- a/work/notes/observations/fork-docs-still-say-overrides-rpcurl-is-dialled.md
+++ b/work/notes/observations/fork-docs-still-say-overrides-rpcurl-is-dialled.md
@@ -1,8 +1,0 @@
----
-title: 'The fork-runs docs still say a fork would dial `overrides.rpcUrl`, which the endpoint refinement already withholds'
-type: observation
-status: spotted
-spotted: 2026-08-29
----
-
-Spotted while landing `a-provider-less-fork-discovers-its-connected-chain-id`. `documentation/fork-runs/index.md`, in the `whenForked` section, says "because the fork layer sits ON TOP of `overrides`, an `overrides.rpcUrl` naming the real network's endpoint would otherwise be what a fork run dials: if your environment entry has one, name the fork's endpoint in `whenForked` as well." `resolveExecutionParams` strips `rpcUrl` from the `overrides` layer on a fork (ADR 0014's endpoint refinement, pinned by `packages/rocketh/test/fork-config-layer.test.ts`), so the remedy the prose asks for is no longer needed and the reason given is stale.


### PR DESCRIPTION
The fork-runs page told readers that because the fork layer sits on top of `overrides`, an `overrides.rpcUrl` naming the real network's endpoint would otherwise be what a fork run dials, so they should restate the fork's endpoint in `whenForked` as well.

That stopped being true in #119, which withholds `overrides.rpcUrl` from a fork's connection entirely. The remedy is unnecessary and the reason given was wrong, which is the worse half: it describes a hazard that no longer exists.

Spotted by the build agent on #121 and correctly captured rather than fixed out of scope; this discharges that observation note. My staleness, from #119.

Verified: `format:check`, `changeset status`, `build`, `typecheck`, `test` (99/99 files, 1152/1152). Documentation only, empty changeset.