### PR TITLE
fix: trim --tags segments, so "a, b" selects a and b

### DIFF
--- a/.changeset/trim-tag-segments.md
+++ b/.changeset/trim-tag-segments.md
@@ -1,0 +1,6 @@
+---
+'@rocketh/node': patch
+'hardhat-deploy': patch
+---
+
+`--tags "a, b"` now selects `a` and `b`. The space a person types after a comma used to become part of the tag, producing `" b"`, which matches no script and then reports itself as "no scripts matched" rather than as a typo, so the flag appeared to work while running only half of what was asked for. Segments are now trimmed and empty ones dropped, so `a,,b` and `a,` behave sensibly too. A value that collapses to nothing (`""`, `" "`, `","`) still means NO filter rather than a filter that matches nothing, which is the case that would otherwise produce a silently do-nothing run. Both entry points parse `--tags` identically, since the rocketh CLI and the hardhat-deploy task must not disagree about what a tag is.

--- a/packages/hardhat-deploy/src/tasks/deploy.ts
+++ b/packages/hardhat-deploy/src/tasks/deploy.ts
@@ -33,7 +33,16 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (a
 	if (args.saveDeployments) {
 		saveDeployments = args.saveDeployments == 'true' ? true : false;
 	}
-	const tags = args.tags && args.tags != '' ? args.tags : undefined;
+	// Segments are TRIMMED and empty ones dropped, so `--tags "a, b"` selects `a` and `b` rather
+	//  than `a` and the unmatchable `" b"`. Everything collapsing to nothing means NO filter, not a
+	//  filter matching nothing, which is why `''` cannot be allowed to become `['']`. `@rocketh/node`
+	//  parses `--tags` identically (`parseTags` in its `cli-options.ts`): the two entry points must
+	//  not disagree about what a tag is.
+	const tagList = args.tags
+		?.split(',')
+		.map((tag) => tag.trim())
+		.filter((tag) => tag !== '');
+	const tags = tagList && tagList.length > 0 ? tagList : undefined;
 
 	setupLogger(packagesWithLogsEnabled, {
 		enabled: true,
@@ -84,7 +93,7 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (a
 		//  the fork escape hatch would be a user-visible change to the flag, not to this task.
 		saveDeployments: isFork ? false : saveDeployments,
 		askBeforeProceeding: skipPrompts ? false : true,
-		tags: tags?.split(','),
+		tags,
 		defaultPollingInterval,
 		reportGasUse: args.reportGasUsed,
 		extra: {connection},

--- a/packages/rocketh-node/src/cli-options.ts
+++ b/packages/rocketh-node/src/cli-options.ts
@@ -132,20 +132,28 @@ export function resolveUnknownSignerPolicy(
  * The option is documented as "comma separated", and a script tag containing a comma is refused
  * by an explicit throw in the executor's selection loop, so splitting on `,` is unambiguous.
  *
- * The empty string is guarded FIRST, and that guard is not cosmetic: splitting `''` yields
- * `['']`, which is a non-empty list, so the filter ENGAGES and matches nothing — a run that
- * silently does no work. `--tags ''` means the same as not passing the flag. hardhat-deploy
- * guards it identically (`args.tags && args.tags != '' ? args.tags : undefined`).
+ * Segments are TRIMMED and empty ones dropped, so `--tags "a, b"` selects `a` and `b`. The space
+ * after a comma is what a person types, and without this it produced the tag `" b"`, which
+ * matches nothing and reports itself as "no scripts matched" rather than as a typo. A leading
+ * space is never part of a tag anyone meant, so reading it literally served no one.
  *
- * Segments are NOT trimmed, matching hardhat-deploy: a tag is whatever the user typed between
- * commas, and quietly editing it would be a second way for the flag to mean something other than
- * it says.
+ * Everything then collapsing to nothing means NO filter, not a filter that matches nothing: that
+ * covers `''`, `' '` and `','` alike. This is the case to keep right, because splitting `''`
+ * yields `['']`, a non-empty list, so the filter would ENGAGE and select no scripts — a run that
+ * silently does no work. `--tags ''` means the same as not passing the flag.
+ *
+ * hardhat-deploy's task option parses identically (`packages/hardhat-deploy/src/tasks/deploy.ts`);
+ * the two entry points must not disagree about what a tag is.
  */
 export function parseTags(value: string | undefined): string[] | undefined {
-	if (value === undefined || value === '') {
+	if (value === undefined) {
 		return undefined;
 	}
-	return value.split(',');
+	const tags = value
+		.split(',')
+		.map((tag) => tag.trim())
+		.filter((tag) => tag !== '');
+	return tags.length > 0 ? tags : undefined;
 }
 
 /**

--- a/packages/rocketh-node/test/cli-tags.test.ts
+++ b/packages/rocketh-node/test/cli-tags.test.ts
@@ -69,6 +69,32 @@ describe('`--tags` reaches core as a LIST', () => {
 		expect(executionParamsFor(['-e', 'memory', '--tags', '']).tags).toBeUndefined();
 		expect(executionParamsFor(['-e', 'memory']).tags).toBeUndefined();
 	});
+
+	/**
+	 * The space after a comma is what a person types. Reading it literally produced the tag `' b'`,
+	 * which matches nothing and then reports itself as "no scripts matched" rather than as a typo,
+	 * so the flag appeared to work while selecting half of what was asked for.
+	 */
+	it('trims the space a person types after a comma', () => {
+		expect(executionParamsFor(['-e', 'memory', '--tags', 'a, b']).tags).toEqual(['a', 'b']);
+		expect(executionParamsFor(['-e', 'memory', '--tags', '  Token  ']).tags).toEqual(['Token']);
+	});
+
+	it('drops empty segments rather than turning them into unmatchable tags', () => {
+		expect(executionParamsFor(['-e', 'memory', '--tags', 'a,,b']).tags).toEqual(['a', 'b']);
+		expect(executionParamsFor(['-e', 'memory', '--tags', 'a,']).tags).toEqual(['a']);
+	});
+
+	/**
+	 * The case the trim must not break: a value that collapses to nothing is NO filter, exactly as
+	 * `''` is. Trimming without dropping would leave `[' ']` engaged and matching nothing, which is
+	 * the do-nothing run this whole area exists to prevent.
+	 */
+	it('treats a value that is only whitespace or commas as no filter', () => {
+		expect(executionParamsFor(['-e', 'memory', '--tags', '   ']).tags).toBeUndefined();
+		expect(executionParamsFor(['-e', 'memory', '--tags', ',']).tags).toBeUndefined();
+		expect(executionParamsFor(['-e', 'memory', '--tags', ' , ']).tags).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------------------------
@@ -162,6 +188,21 @@ describe('`rocketh --tags <value>` selects the scripts carrying that tag', () =>
 		writeTaggedScript('c-script', ['c']);
 
 		await runCLI(['--tags', 'a,b']);
+
+		expect(scriptsThatRan().sort()).toEqual(['a-script', 'b-script']);
+	});
+
+	/**
+	 * The same command with the space a person actually types. Before the segments were trimmed
+	 * this ran `a-script` ONLY, and said nothing about `b`: a partial run that looks like a
+	 * successful one, which is worse than an error.
+	 */
+	it('runs both for `--tags "a, b"`, the way a person types it', async () => {
+		writeTaggedScript('a-script', ['a']);
+		writeTaggedScript('b-script', ['b']);
+		writeTaggedScript('c-script', ['c']);
+
+		await runCLI(['--tags', 'a, b']);
 
 		expect(scriptsThatRan().sort()).toEqual(['a-script', 'b-script']);
 	});


### PR DESCRIPTION
The space a person types after a comma used to become part of the tag, producing `" b"`. That matches no script, and the run then reports itself as "no scripts matched" rather than as a typo, so the flag appeared to work while running only half of what was asked for. A partial run that looks like a successful one is worse than an error.

Segments are now trimmed and empty ones dropped, so `a,,b` and `a,` behave sensibly too.

### The case the trim must not break

A value that collapses to nothing (`""`, `" "`, `","`) still means **no filter**, not a filter that matches nothing. Trimming without dropping would leave `[" "]` engaged and selecting no scripts, which is the same silently-do-nothing run the previous fix was about, arrived at from the other side. It is tested from all three spellings.

### Both entry points

`hardhat-deploy`'s task option is parsed identically. The rocketh CLI and the hardhat task must not disagree about what a tag is, and that divergence was the stated reason the previous PR left this alone.

### Tests

Four new, verified non-vacuous: reverting `parseTags` fails exactly those four and leaves the other seventeen passing. Three are unit-level over the parsed shape, and one drives the real executor from argv (`--tags "a, b"` runs both scripts), because that is the level at which the old behaviour looked like success.

Full configured chain green: `format:check`, `sync:template:check`, `changeset status`, `build`, `typecheck`, `test` (100/100 files, 1173/1173) and `test:getting-started`.