### PR TITLE
feat(rocketh)!: drop the undocumented ExecutionParams.network alias

### DIFF
--- a/.changeset/drop-network-alias.md
+++ b/.changeset/drop-network-alias.md
@@ -1,0 +1,5 @@
+---
+'rocketh': minor
+---
+
+`ExecutionParams.network` is removed. It was an undocumented alias for `environment`, readable only because `getEnvironmentName` reached for it through a cast (`(executionParams as any).network`): it appeared in no type, nothing in this repo passed it, and no documentation mentioned it, so only a JavaScript caller could have been relying on it. Passing it now throws an error naming `environment`, rather than being ignored: ignoring it would turn `{network: 'mainnet'}` into the default in-memory run, so a caller who meant mainnet would get a run that deploys nowhere and reports nothing wrong. A caller still passing `network` should rename it to `environment`, which has always accepted the same value.

--- a/packages/rocketh/src/executor/index.ts
+++ b/packages/rocketh/src/executor/index.ts
@@ -299,7 +299,18 @@ export async function getChainIdForExecutionParams(
  * forked network is layered on by `resolveForkDescriptor`, which has the config.
  */
 export function getEnvironmentName(executionParams: ExecutionParams): {name: string; fork?: ForkDescriptor} {
-	const environmentProvided = executionParams.environment || (executionParams as any).network;
+	// `network` was an undocumented alias for `environment`, readable only through a cast because it
+	// appears in no type. It is REFUSED rather than quietly ignored: ignoring it would turn
+	// `{network: 'mainnet'}` into the default in-memory run, so a caller who meant mainnet would get
+	// a run that deploys nowhere and says nothing, which is precisely the silent-misbehaviour class
+	// the option boundary in `@rocketh/node` was just rebuilt to end. An alias nobody can see in the
+	// types is not worth keeping; an actionable error costs one branch.
+	if ((executionParams as {network?: unknown}).network !== undefined) {
+		throw new Error(
+			'`network` is not an execution parameter: use `environment`. It was an undocumented alias for it and has been removed.',
+		);
+	}
+	const environmentProvided = executionParams.environment;
 	let environmentName = 'memory';
 	let fork: ForkDescriptor | undefined;
 	if (environmentProvided) {

--- a/packages/rocketh/test/resolve-config-params.test.ts
+++ b/packages/rocketh/test/resolve-config-params.test.ts
@@ -87,10 +87,21 @@ describe('getEnvironmentName', () => {
 		expect(fork).toBeUndefined();
 	});
 
-	it('accepts the legacy "network" key', () => {
-		const {name, fork} = getEnvironmentName({network: 'mainnet'} as any);
-		expect(name).toBe('mainnet');
-		expect(fork).toBeUndefined();
+	/**
+	 * `network` was an undocumented alias for `environment`, readable only through a cast. It is
+	 * REFUSED rather than ignored: ignoring it would make `{network: 'mainnet'}` the default
+	 * in-memory run, so a caller who meant mainnet would get one that deploys nowhere and says
+	 * nothing. The error is the whole point of the removal, so it is what gets pinned.
+	 */
+	it('refuses the removed "network" alias instead of silently running in memory', () => {
+		expect(() => getEnvironmentName({network: 'mainnet'} as any)).toThrowError(
+			/`network` is not an execution parameter/,
+		);
+		expect(() => getEnvironmentName({network: {fork: 'mainnet'}} as any)).toThrowError(/use `environment`/);
+	});
+
+	it('is unaffected by an absent "network" key, which is every real caller', () => {
+		expect(getEnvironmentName({environment: 'sepolia', network: undefined} as any).name).toBe('sepolia');
 	});
 
 	it('unwraps the fork object form {fork: "mainnet"} into a descriptor naming it', () => {


### PR DESCRIPTION
Closes the hole the `--tags` work surfaced: `getEnvironmentName` read `executionParams.environment || (executionParams as any).network`.

`network` appeared in no type, nothing in this repo passed it, and no documentation mentioned it. It existed only because a cast let it, which is the same class of hole the CLI's blanket `options as ExecutionParams` cast turned out to be: a field no type mentions, kept reachable by switching the compiler off.

### It throws rather than being ignored

This is the one judgement call here, so flagging it. Simply deleting the fallback would make `{network: "mainnet"}` resolve to the default **in-memory** run, so a caller who meant mainnet would get a run that deploys nowhere and reports nothing wrong. That is exactly the silent-misbehaviour class the option boundary was just rebuilt to end, so passing `network` now throws an error naming `environment`. One branch, and the only actionable outcome.

Say if you would rather it were simply removed; it is a two-line change either way.

### Blast radius

Only a JavaScript caller could have been relying on it, since TypeScript users cannot pass a field the type does not declare without a cast of their own. The migration is a rename to `environment`, which has always accepted the same value. Marked `minor` rather than `patch` because it is a removal, and called out in the changeset.

The one place in the repo that used it was a test documenting the alias; it now pins the refusal instead, in both the string and the fork-object spellings.

Full configured chain green: `format:check`, `sync:template:check`, `changeset status`, `build`, `typecheck`, `test` (100/100 files, 1174/1174) and `test:getting-started`.