### PR TITLE
feat(re-ask-a-not-found-pasted-hash-with-the-previous-value): Re-ask fo…

### DIFF
--- a/.changeset/re-ask-a-not-found-pasted-hash.md
+++ b/.changeset/re-ask-a-not-found-pasted-hash.md
@@ -1,0 +1,8 @@
+---
+'@rocketh/core': minor
+'@rocketh/node': minor
+'@rocketh/test-utils': minor
+'rocketh': minor
+---
+
+A transaction hash pasted at the interactive unknown-signer prompt that this node has never heard of no longer ends the run: the question is asked again with that hash offered back as the starting value, so a truncated paste, a dropped character or an RPC that had not caught up costs an edit rather than a re-run. Pressing enter on the offered value looks for the same hash again. The re-asking is bounded and shares ONE budget of three questions per pause with the existing malformed-paste re-ask, so alternating the two cannot loop; when it runs out the transaction defers exactly as `cannot sign` does, saving nothing. `PromptExecutor.promptText` requests gain an optional `initial` (the new `TextPromptRequest` type), honoured by `@rocketh/node` through the prompt library's own initial-value support, recorded by the `@rocketh/test-utils` double, and safely ignorable elsewhere; `@rocketh/web` still supplies no text ability.

--- a/documentation/unknown-signers/index.md
+++ b/documentation/unknown-signers/index.md
@@ -14,8 +14,16 @@ That is the whole workflow. There is no re-run dance, nothing to install, and an
 
 ### At the pause you have two answers
 
-- **Paste the transaction hash.** rocketh looks the transaction up on the network, waits for it to be mined, requires the receipt to report a SUCCESSFUL status, saves state through the same pending-transaction path a normal broadcast uses, records the hash for gas reporting, and returns the receipt to your script. It never sends a transaction of its own. A hash this node has never heard of (from the wrong network, or a typo that is still the right shape) is given a short grace period to show up and then reported as not found, with the transaction you still have to execute printed again, so the run stops rather than waiting for ever.
-- **`cannot sign`** (or just press enter). rocketh prints the full transaction and raises `UnknownSignerError`, which is the [defer workflow](#deferring-instead-of-asking-catchunknownsigner) below. Aborting the prompt (Ctrl-C) does the same. A paste that is not a transaction hash is re-asked a couple of times and then also defers.
+- **Paste the transaction hash.** rocketh looks the transaction up on the network, waits for it to be mined, requires the receipt to report a SUCCESSFUL status, saves state through the same pending-transaction path a normal broadcast uses, records the hash for gas reporting, and returns the receipt to your script. It never sends a transaction of its own.
+- **`cannot sign`** (or just press enter). rocketh prints the full transaction and raises `UnknownSignerError`, which is the [defer workflow](#deferring-instead-of-asking-catchunknownsigner) below. Aborting the prompt (Ctrl-C) does the same.
+
+### A hash that does not work out is asked again, not fatal
+
+A paste can be wrong in two ways, and neither ends the run. A value that is **not a transaction hash** (you pasted an address, or half a line) is rejected on the spot. A hash this node has **never heard of** (copied from the wrong network's explorer, or a character your terminal ate) is given a short grace period to show up and then reported as not found. Either way rocketh asks the same question again, and for a not-found hash it offers the value you typed BACK to you: press enter to look for that same hash once more, which is what you want when the transaction is real and the RPC had simply not caught up, or type a corrected one.
+
+The re-asking is BOUNDED: **one pause asks at most three times in total**, and the two kinds of bad answer share that budget, so a prompt nobody is really answering cannot pause a run for ever. When it runs out, the transaction is deferred exactly as `cannot sign` defers it: the full transaction is printed, `UnknownSignerError` is raised, and nothing is saved. The exits work from the re-asked question too, so you are never held at a prompt you cannot satisfy: an empty answer, `cannot sign` and Ctrl-C all defer.
+
+Nothing is recorded for a hash that was refused. The checks below all run before rocketh writes anything at all, so a rejected paste leaves no deployment record, no pending-transaction file and no gas-tracker entry, and the invariants are applied to the hash you FINALLY gave it, not to an earlier attempt.
 
 ### A hash from an earlier run is still good
 

--- a/packages/rocketh-core/src/types.ts
+++ b/packages/rocketh-core/src/types.ts
@@ -1041,6 +1041,28 @@ export type PromptAnswer = {
  */
 export type TextPromptAnswer = {value: string} | {cancelled: true};
 
+/**
+ * What asking a human for free TEXT looks like on the wire.
+ *
+ * `initial` is a HINT, not a contract: an implementation that has no way to offer a
+ * starting value ignores it and the caller still works, which is what keeps the field
+ * safe to add to an interface every runtime implements. The caller therefore may not
+ * assume the answer came back pre-filled — it re-reads whatever the human submitted,
+ * exactly as it would without the hint.
+ *
+ * It exists so a re-ask does not throw away what the human already typed: the
+ * interactive unknown-signer resolver re-asks a hash the node could not find with that
+ * hash offered back, so a truncated paste or a dropped character costs an edit rather
+ * than a re-run.
+ */
+export type TextPromptRequest = {
+	type: 'text';
+	name: string;
+	message: string;
+	/** A starting value to offer the human, e.g. the answer they gave to the same question a moment ago. */
+	initial?: string;
+};
+
 export interface PromptExecutor {
 	prompt(request: {type: 'confirm'; name: string; message: string}): Promise<PromptAnswer>;
 	/**
@@ -1052,6 +1074,6 @@ export interface PromptExecutor {
 	 * `PromptExecutor`: `@rocketh/web` ships one whose confirm auto-proceeds without
 	 * asking anyone. Check `env.canPromptForText()` instead.
 	 */
-	promptText?(request: {type: 'text'; name: string; message: string}): Promise<TextPromptAnswer>;
+	promptText?(request: TextPromptRequest): Promise<TextPromptAnswer>;
 	exit(): void;
 }

--- a/packages/rocketh-node/src/environment/prompt.ts
+++ b/packages/rocketh-node/src/environment/prompt.ts
@@ -1,5 +1,5 @@
 import prompts from 'prompts';
-import type {PromptExecutor} from '@rocketh/core/types';
+import type {PromptExecutor, TextPromptRequest} from '@rocketh/core/types';
 
 /**
  * The Node runtime's way of asking a human something, and the only one in this repo
@@ -70,7 +70,18 @@ export function createNodePromptExecutor(options?: {
 	};
 
 	if (isStdinInteractive()) {
-		executor.promptText = async (request: {type: 'text'; name: string; message: string}) => {
+		// `request` is handed to `prompts` WHOLE, which is what carries the optional `initial`
+		// through: `prompts` accepts it natively on a text prompt. Beware what it means there,
+		// because "pre-filled" oversells it. `initial` renders GREYED as a placeholder and
+		// becomes the answer only when the human submits an untouched line (`TextPrompt.submit`
+		// does `this.value = this.value || this.initial`); typing replaces it wholesale, and the
+		// right-arrow / tab key pulls it into the editable buffer (`TextPrompt.next`). So enter
+		// means "try that same hash again", which is exactly what the interactive re-ask wants.
+		// CTRL-C IS UNAFFECTED: an aborted text prompt REJECTS, so `prompts` returns with the
+		// key absent and the abort still reads as a cancellation rather than as the offered
+		// value. This is also why `initial` is documented as a HINT on `TextPromptRequest`: a
+		// runtime with no equivalent may ignore it and stay correct.
+		executor.promptText = async (request: TextPromptRequest) => {
 			const answer = await prompts<string>(request);
 			// `prompts` keys its answer object BY `request.name`, so read it by name. Reading a
 			// fixed key here would make every prompt not named that silently answer `undefined`.

--- a/packages/rocketh-node/test/prompt-executor.test.ts
+++ b/packages/rocketh-node/test/prompt-executor.test.ts
@@ -101,6 +101,32 @@ describe('@rocketh/node - prompt executor', () => {
 			expect(promptsMock).toHaveBeenCalledWith(request);
 		});
 
+		/**
+		 * THE PRE-FILL. A re-ask ("that hash is not one this node knows — try again") offers
+		 * the previous answer back, and `prompts` has native support for exactly that: an
+		 * `initial` on a text prompt renders greyed and becomes the answer when the human
+		 * submits an untouched line, so pressing enter means "try that same hash again".
+		 * Reaching the library is all this runtime has to do, and all it does.
+		 */
+		it('passes a pre-filled initial value through to the prompts library', async () => {
+			promptsMock.mockResolvedValue({txHash: '0xdeadbeef'});
+
+			const answer = await interactiveExecutor().promptText!({
+				type: 'text',
+				name: 'txHash',
+				message: 'paste the transaction hash',
+				initial: '0xdeadbeef',
+			});
+
+			expect(promptsMock).toHaveBeenCalledWith({
+				type: 'text',
+				name: 'txHash',
+				message: 'paste the transaction hash',
+				initial: '0xdeadbeef',
+			});
+			expect(answer).toEqual({value: '0xdeadbeef'});
+		});
+
 		it('reports cancellation when the user aborts (prompts answers nothing)', async () => {
 			// Ctrl-C: `prompts` resolves with the key absent rather than rejecting.
 			promptsMock.mockResolvedValue({});

--- a/packages/rocketh-test-utils/src/mock-prompt.ts
+++ b/packages/rocketh-test-utils/src/mock-prompt.ts
@@ -24,12 +24,22 @@
  * (`{textAnswers: []}`), which is a present-but-exhausted prompt.
  */
 
-import type {PromptExecutor, TextPromptAnswer} from '@rocketh/core/types';
+import type {PromptExecutor, TextPromptAnswer, TextPromptRequest} from '@rocketh/core/types';
 
 /** A confirm ask, as `PromptExecutor.prompt` receives it. */
 export type MockConfirmPromptRequest = {type: 'confirm'; name: string; message: string};
-/** A free-text ask, as `PromptExecutor.promptText` receives it. */
-export type MockTextPromptRequest = {type: 'text'; name: string; message: string};
+/**
+ * A free-text ask, as `PromptExecutor.promptText` receives it — the request type
+ * ITSELF, so a field added to the abstraction is recorded here without this double
+ * having to be widened again.
+ *
+ * It carries `initial`, the starting value the asker offered, which is how a test
+ * proves a RE-ASK carried the previous answer over rather than asking from scratch:
+ * `promptExecutor.textRequests[1].initial`. A real prompt would show it; this one only
+ * records it, and answers from its script regardless — the script IS what the human
+ * typed, and a human is free to ignore what they were offered.
+ */
+export type MockTextPromptRequest = TextPromptRequest;
 export type MockPromptRequest = MockConfirmPromptRequest | MockTextPromptRequest;
 
 /**

--- a/packages/rocketh-test-utils/test/mockPromptExecutor.test.ts
+++ b/packages/rocketh-test-utils/test/mockPromptExecutor.test.ts
@@ -95,6 +95,31 @@ describe('createMockPromptExecutor', () => {
 		);
 	});
 
+	it('records the value a RE-ASK offered back as the starting point', async () => {
+		/**
+		 * `initial` is how the interactive unknown-signer resolver re-asks for a hash this
+		 * node could not find without throwing away what the human already typed. Recording
+		 * it is what lets a test prove the previous answer was CARRIED OVER, rather than the
+		 * question being asked again from scratch — which looks identical if all a test can
+		 * count is how many times the prompt was consulted.
+		 *
+		 * The double answers from its script whatever it was offered, exactly as a human is
+		 * free to type over the value in front of them.
+		 */
+		const promptExecutor = createMockPromptExecutor({textAnswers: [A_HASH, A_HASH]});
+
+		await promptExecutor.promptText!({type: 'text', name: 'transactionHash', message: 'hash?'});
+		await promptExecutor.promptText!({
+			type: 'text',
+			name: 'transactionHash',
+			message: 'hash?',
+			initial: A_HASH,
+		});
+
+		expect(promptExecutor.textRequests[0].initial).toBeUndefined();
+		expect(promptExecutor.textRequests[1].initial).toBe(A_HASH);
+	});
+
 	it('does not consume a caller-owned answers array', async () => {
 		const answers = [A_HASH];
 		const first = createMockPromptExecutor({textAnswers: answers});

--- a/packages/rocketh/src/environment/index.ts
+++ b/packages/rocketh/src/environment/index.ts
@@ -32,7 +32,12 @@ import {
 	describeUnknownSignerCapabilityDegradation,
 	resolveUnknownSignerBehaviour,
 } from './unknownSignerPolicy.js';
-import {askForExecutedTransactionHash, confirmUnrelatedTransaction} from './interactiveUnknownSigner.js';
+import {
+	askForExecutedTransactionHash,
+	confirmUnrelatedTransaction,
+	createHashPromptBudget,
+	describeRemainingAttempts,
+} from './interactiveUnknownSigner.js';
 import {classifyPastedTransaction, describeEvidence} from './pastedTransactionIntent.js';
 import {Abi, Address} from 'abitype';
 import {InternalEnvironment} from '../internal/types.js';
@@ -239,11 +244,13 @@ function wait(numSeconds: number): Promise<void> {
 
 /**
  * How many rounds a hash PASTED at the interactive unknown-signer prompt gets to become
- * KNOWN to this node before the run gives up on it.
+ * KNOWN to this node before the run stops looking for THAT hash and asks again.
  *
  * It bounds only the "this node has never heard of that hash" case (a typo, a hash from
  * another chain), never the wait for MINING: a transaction the node knows is waited for
- * like any other. The wall-clock length is the run's own `pollingInterval` times this,
+ * like any other. Giving up on a hash no longer ends the run: the human is asked again
+ * with that hash pre-filled, and it is the shared budget of questions one pause may ask
+ * (`MAX_HASH_PROMPT_ATTEMPTS`) that bounds how often this can happen. The wall-clock length is the run's own `pollingInterval` times this,
  * so a chain configured to poll slowly stretches the grace period exactly as it
  * stretches every other wait, and a test that polls fast is fast.
  */
@@ -1541,36 +1548,76 @@ export async function createEnvironment<
 				// a DEPLOYMENT from an unsignable `from` resolves interactively too, inherits the
 				// successful-status invariant below, and then gets the ADDRESS invariants that an
 				// execution cannot have (`requireDeployedContract`).
-				const answer = await askForExecutedTransactionHash({
-					promptText: promptExecutor!.promptText!,
-					// Routed through `env` (not the local closure) so a caller/test that replaces
-					// `showMessage` sees what the human was shown.
-					showMessage: (message) => env.showMessage(message),
-					// The error MESSAGE is the deliverable of the deferral workflow, so the
-					// interactive path shows exactly it, never a summary of it.
-					details: unknownSignerError.message,
-					from: transactionData.from,
-				});
-				if (answer.type === 'cannot-sign') {
-					// "cannot sign" DEGRADES to the defer path: the same error, undegraded, so it
-					// is caught by `catchUnknownSigner` exactly as an unwrapped throw would be.
-					logger.debug(`interactive unknown-signer resolution declined (${answer.reason})`);
-					throw unknownSignerError;
-				}
+				//
+				// ASK, LOOK UP, AND ASK AGAIN IF THIS NODE HAS NEVER HEARD OF THE HASH. The loop
+				// exists because the two commonest ways a paste fails (a truncated line, a
+				// character the terminal ate, the right hash a moment before the RPC caught up)
+				// used to cost the whole run: giving up printed the transaction again and threw.
+				// Re-asking with the value pre-filled turns that into an edit.
+				//
+				// IT TERMINATES because every iteration spends at least one unit of `budget`
+				// inside `askForExecutedTransactionHash` (a single shared budget, also spent by
+				// the malformed-paste re-asks INSIDE that call), and an empty budget answers
+				// `cannot-sign` without asking anything, which leaves through the `throw` below.
+				// So the pause costs at most `MAX_HASH_PROMPT_ATTEMPTS` questions no matter how
+				// the two kinds of bad answer are interleaved, and no wall clock is involved.
+				const budget = createHashPromptBudget();
+				let previousAnswer: string | undefined;
+				let accepted:
+					{hash: `0x${string}`; receipt: EIP1193TransactionReceipt; transaction: EIP1193Transaction} | undefined;
+				while (!accepted) {
+					const answer = await askForExecutedTransactionHash({
+						promptText: promptExecutor!.promptText!,
+						// Routed through `env` (not the local closure) so a caller/test that replaces
+						// `showMessage` sees what the human was shown.
+						showMessage: (message) => env.showMessage(message),
+						// The error MESSAGE is the deliverable of the deferral workflow, so the
+						// interactive path shows exactly it, never a summary of it.
+						details: unknownSignerError.message,
+						from: transactionData.from,
+						budget,
+						previousAnswer,
+					});
+					if (answer.type === 'cannot-sign') {
+						// "cannot sign" DEGRADES to the defer path: the same error, undegraded, so it
+						// is caught by `catchUnknownSigner` exactly as an unwrapped throw would be.
+						// A budget spent on hashes nobody could find arrives HERE too, rather than at
+						// the bespoke "not found" failure this path used to raise: one pause has one
+						// giving-up outcome, and deferring is the one that a `catchUnknownSigner`
+						// wrapper can still handle.
+						logger.debug(`interactive unknown-signer resolution declined (${answer.reason})`);
+						throw unknownSignerError;
+					}
 
-				// The transaction has to be FOUND on this network and have SUCCEEDED before the
-				// run records anything: checked BEFORE anything is saved or tracked, so a failed,
-				// or simply non-existent, transaction leaves no state behind at all.
-				const {receipt, transaction: pastedTransaction} = await waitForPastedTransaction(
-					answer.hash,
-					unknownSignerError,
-				);
+					// The transaction has to be FOUND on this network and have SUCCEEDED before the
+					// run records anything: checked BEFORE anything is saved or tracked, so a failed,
+					// or simply non-existent, transaction leaves no state behind at all.
+					const located = await waitForPastedTransaction(answer.hash, unknownSignerError);
+					if (located.type === 'not-found') {
+						// The message that used to be the failure, minus the transaction to execute:
+						// the human is still looking at the pause that printed it, and the deferral at
+						// the end of the budget prints it again anyway.
+						env.showMessage(
+							`  - the transaction you pasted (${answer.hash}) was not found on this network: after ` +
+								`${PASTED_TRANSACTION_LOOKUP_ROUNDS} attempts the node still does not know it. Check you ` +
+								`pasted the hash of a transaction executed on this very network. Nothing was saved.` +
+								describeRemainingAttempts(budget),
+						);
+						// Carried into the next ask so the human edits it rather than retyping it.
+						previousAnswer = answer.hash;
+						continue;
+					}
+					accepted = {hash: answer.hash, receipt: located.receipt, transaction: located.transaction};
+				}
+				const {hash: acceptedHash, receipt, transaction: pastedTransaction} = accepted;
 
 				// A DEPLOYMENT is held to a stricter standard than an execution, because it HAS an
 				// address to anchor on. Checked here, at the same point as the status and before
 				// anything is saved or tracked, so a hash that deployed nothing leaves no state.
+				// Run on the hash finally ACCEPTED, which after a re-ask is not the first one
+				// pasted.
 				if (source.type === 'deployment') {
-					await requireDeployedContract(source, receipt, answer.hash, unknownSignerError);
+					await requireDeployedContract(source, receipt, acceptedHash, unknownSignerError);
 				} else {
 					// IS IT THE TRANSACTION WE ASKED FOR? A successful receipt used to be the whole of
 					//  the check for an execution, so an unrelated successful hash was taken at face
@@ -1587,13 +1634,13 @@ export async function createEnvironment<
 							promptText: promptExecutor!.promptText!,
 							showMessage: (message) => env.showMessage(message),
 							finding,
-							hash: answer.hash,
+							hash: acceptedHash,
 						});
 						if (confirmation.type === 'rejected') {
 							// DEGRADES to the defer path, exactly as "cannot sign" does: the same error,
 							//  undegraded, so `catchUnknownSigner` handles it identically and nothing is saved
 							//  for a transaction the user would not vouch for.
-							logger.debug(`pasted transaction ${answer.hash} not confirmed (${confirmation.reason})`);
+							logger.debug(`pasted transaction ${acceptedHash} not confirmed (${confirmation.reason})`);
 							throw unknownSignerError;
 						}
 					} else {
@@ -1606,11 +1653,11 @@ export async function createEnvironment<
 				// The tracker only records hashes it OBSERVES on `eth_sendTransaction` /
 				// `eth_sendRawTransaction`, so a transaction executed elsewhere would be invisible
 				// to it and gas reporting (which iterates this list) would silently omit it.
-				provider.transactionHashes.push(answer.hash);
+				provider.transactionHashes.push(acceptedHash);
 
 				// Hand the receipt to the pipeline about to wait for this same hash, so the user
 				// does not watch two waits for one transaction.
-				pastedTransactionReceipts.set(answer.hash, receipt);
+				pastedTransactionReceipts.set(acceptedHash, receipt);
 
 				// CAPTURED, and only HERE: every earlier exit from this branch either deferred the
 				// transaction (the `throw` policy, "cannot sign", a paste the user would not vouch
@@ -1627,7 +1674,7 @@ export async function createEnvironment<
 				// (`savePendingExecution` / `savePendingDeployment` → `eth_getTransactionByHash`
 				// → `waitForTransaction`). Nothing about pending state or receipt waiting is
 				// reimplemented here.
-				return answer.hash;
+				return acceptedHash;
 			}
 
 			const signer = env.addressSigners[from];
@@ -1706,7 +1753,8 @@ export async function createEnvironment<
 	}
 
 	/**
-	 * Turn a hash the user PASTED into a receipt this run may act on, or fail loudly.
+	 * Turn a hash the user PASTED into a receipt this run may act on, report that this
+	 * node has never heard of it, or fail loudly.
 	 *
 	 * Two things can be wrong with a pasted hash, and they need different treatment:
 	 *
@@ -1714,8 +1762,14 @@ export async function createEnvironment<
 	 *   a typo that is still 64 hex characters). The lookup is BOUNDED
 	 *   ({@link PASTED_TRANSACTION_LOOKUP_ROUNDS} rounds at the run's own polling
 	 *   interval, enough for a just-broadcast transaction to reach this node) and then
-	 *   gives up, naming the hash as not found. Polling for it for ever would park the
-	 *   run behind a spinner with Ctrl-C as the only exit.
+	 *   RETURNS `not-found`. Polling for it for ever would park the run behind a spinner
+	 *   with Ctrl-C as the only exit.
+	 *
+	 *   Returning rather than throwing is what lets the caller RE-ASK with the hash
+	 *   pre-filled instead of ending the run on a dropped character; the bound the throw
+	 *   used to enforce moves up with it, to the shared budget of questions one pause may
+	 *   ask (`MAX_HASH_PROMPT_ATTEMPTS`). This function stays bounded either way, which is
+	 *   what makes that composition safe.
 	 * - IT EXISTS BUT HAS NOT SUCCEEDED (yet). Once the node knows the transaction, the
 	 *   wait for its receipt is the ORDINARY unbounded one any transaction rocketh sends
 	 *   itself gets, confirmations included: a Safe execution can legitimately take a
@@ -1724,14 +1778,20 @@ export async function createEnvironment<
 	 *   MultiSend/Timelock payload or to match `to`/`data` (the accepted residual risk,
 	 *   documented under "Handling unknown signers").
 	 *
-	 * Both failures name BOTH the transaction rocketh needed executed and the hash that
-	 * was pasted, because those are the two things needed to work out what went wrong.
-	 * Nothing is saved and nothing is tracked when either fires: this runs before both.
+	 *   A receipt that did NOT succeed still THROWS here, and is deliberately not re-asked:
+	 *   the node knows exactly what happened to that transaction and asking again cannot
+	 *   change it, so the run stops with the reverting hash and the transaction that still
+	 *   needs executing both named.
+	 *
+	 * Nothing is saved and nothing is tracked on any of these outcomes: this runs before
+	 * the pending-transaction file, the gas tracker and the deployment record.
 	 */
 	async function waitForPastedTransaction(
 		hash: `0x${string}`,
 		unknownSignerError: UnknownSignerError,
-	): Promise<{receipt: EIP1193TransactionReceipt; transaction: EIP1193Transaction}> {
+	): Promise<
+		{type: 'found'; receipt: EIP1193TransactionReceipt; transaction: EIP1193Transaction} | {type: 'not-found'}
+	> {
 		const lookupSpinner = spin(`  - Looking for the transaction you pasted:\n      ${hash}`);
 		let transaction: EIP1193Transaction | null = null;
 		for (let round = 1; !transaction; round++) {
@@ -1746,12 +1806,9 @@ export async function createEnvironment<
 			if (!transaction) {
 				if (round >= PASTED_TRANSACTION_LOOKUP_ROUNDS) {
 					lookupSpinner.fail();
-					throw new Error(
-						`The transaction you pasted (${hash}) was not found on this network: after ` +
-							`${PASTED_TRANSACTION_LOOKUP_ROUNDS} attempts the node still does not know it. Check you ` +
-							`pasted the hash of a transaction executed on this very network. Nothing was saved.\n` +
-							`The transaction that still needs executing:\n${unknownSignerError.message}`,
-					);
+					// WHY it gave up is said by the caller, which is the one that knows whether the
+					// human gets another go at it.
+					return {type: 'not-found'};
 				}
 				await wait(resolvedExecutionParams.pollingInterval);
 			}
@@ -1776,7 +1833,7 @@ export async function createEnvironment<
 		// The TRANSACTION travels with the receipt because the caller has to weigh whether this is
 		//  the transaction it asked for, and only the transaction carries `to` / `input` / `value`.
 		//  It was fetched above anyway, so this costs no extra call.
-		return {receipt, transaction};
+		return {type: 'found', receipt, transaction};
 	}
 
 	/**

--- a/packages/rocketh/src/environment/interactiveUnknownSigner.ts
+++ b/packages/rocketh/src/environment/interactiveUnknownSigner.ts
@@ -17,24 +17,58 @@ const SEPARATOR = '-------------------------------------------------------------
 export const CANNOT_SIGN_ANSWER = 'cannot sign';
 
 /**
- * How many times a malformed paste is re-asked before the run gives up and defers.
+ * How many times ONE unsignable transaction may be asked for a hash, in TOTAL.
+ *
  * BOUNDED on purpose: a typo deserves a second chance, but an unattended or
  * mis-wired prompt that keeps answering nonsense must not be able to spin a run
  * forever. Giving up degrades to the same defer path as "cannot sign", so nothing
  * is lost but the pause.
+ *
+ * ONE BUDGET, SHARED BY BOTH RE-ASKS. A paste can fail two different ways — it is not
+ * a well-formed hash (a SYNTAX failure, caught here) or the node has never heard of it
+ * (a LOOKUP failure, caught at the seam, which then re-asks with the value pre-filled).
+ * They deliberately spend the SAME counter, because two counters that each reset are
+ * how an unbounded loop arrives by accident: alternating one malformed answer with one
+ * unfindable hash would refill whichever budget the other kind did not touch, and the
+ * run could be paused for ever. With one budget the whole pause costs at most this many
+ * questions whatever the answers are, which is the property {@link HashPromptBudget}
+ * exists to make provable.
  */
 export const MAX_HASH_PROMPT_ATTEMPTS = 3;
+
+/**
+ * The remaining share of {@link MAX_HASH_PROMPT_ATTEMPTS} for ONE unsignable
+ * transaction: created once per pause and passed to every ask, so the two re-ask paths
+ * spend one counter rather than one each.
+ *
+ * Mutable and passed by reference on purpose. The counter has to be spent by code on
+ * BOTH sides of this module's boundary (the malformed-paste loop here, the not-found
+ * re-ask at the seam), and a returned-and-rethreaded number is the shape where one
+ * caller forgets to thread it back and the bound quietly dies.
+ */
+export type HashPromptBudget = {remaining: number};
+
+/** Open a fresh budget for one pause. Never reused across transactions. */
+export function createHashPromptBudget(): HashPromptBudget {
+	return {remaining: MAX_HASH_PROMPT_ATTEMPTS};
+}
 
 const TRANSACTION_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 
 /**
  * The answer, already validated. `cannot-sign` carries WHY so the seam (and a log)
  * can tell a deliberate decline from an aborted prompt, a prompt that could not run
- * at all, or a paste that never became a hash.
+ * at all, or a pause that ran out of questions.
+ *
+ * `attempts-exhausted` is the {@link HashPromptBudget} reaching zero, whatever spent
+ * it: malformed pastes here, hashes this node never found, or a mix of the two. It is
+ * deliberately NOT named after malformed input (which it once was, as `no-valid-hash`),
+ * because the budget is shared and naming it after one of its two spenders would read
+ * as a lie on the other path.
  */
 export type InteractiveUnknownSignerAnswer =
 	| {type: 'hash'; hash: `0x${string}`}
-	| {type: 'cannot-sign'; reason: 'declined' | 'cancelled' | 'prompt-failed' | 'no-valid-hash'};
+	| {type: 'cannot-sign'; reason: 'declined' | 'cancelled' | 'prompt-failed' | 'attempts-exhausted'};
 
 /** Normalise so `Cannot-Sign`, `cannot_sign` and `CANNOT  SIGN` all mean the same thing. */
 function normaliseAnswer(value: string): string {
@@ -83,6 +117,11 @@ export function formatInteractivePresentation(details: string, from: string): st
  * which an EMPTY string is a VALUE, not a cancellation, precisely because only the
  * caller knows what its prompt can accept. This caller accepts a 32-byte hex hash
  * and reads everything else as a decision or a typo.
+ *
+ * CALLED ONCE PER ASK-AND-LOOKUP CYCLE, not once per pause: the seam calls it again
+ * when the hash it got back turned out to be unknown to this node, passing that hash
+ * as `previousAnswer`. Every call spends from the SAME `budget`, so the pause as a
+ * whole is bounded however the two kinds of bad answer are interleaved.
  */
 export async function askForExecutedTransactionHash(params: {
 	promptText: NonNullable<PromptExecutor['promptText']>;
@@ -90,18 +129,38 @@ export async function askForExecutedTransactionHash(params: {
 	/** The `UnknownSignerError` message: the transaction to execute, undegraded. */
 	details: string;
 	from: string;
+	/** Shared across every ask for this one transaction. See {@link HashPromptBudget}. */
+	budget: HashPromptBudget;
+	/**
+	 * The hash asked about a moment ago, when this is a RE-ASK of a pause the human is
+	 * ALREADY looking at (the seam looked it up and this node did not know it).
+	 *
+	 * Its PRESENCE means two things, which are one thing seen from either end: the
+	 * value is offered back as the prompt's starting point, so a truncated paste or a
+	 * dropped character costs an edit rather than a re-run; and the transaction banner is
+	 * NOT printed again, because it is still on screen above the question that produced
+	 * this value. (The malformed-paste loop below re-asks without reprinting it for the
+	 * same reason.) A first ask has no previous answer and gets the banner.
+	 */
+	previousAnswer?: string;
 }): Promise<InteractiveUnknownSignerAnswer> {
-	const {promptText, showMessage, details, from} = params;
+	const {promptText, showMessage, details, from, budget, previousAnswer} = params;
 
-	showMessage(formatInteractivePresentation(details, from));
+	if (previousAnswer === undefined) {
+		showMessage(formatInteractivePresentation(details, from));
+	}
 
-	for (let attempt = 1; attempt <= MAX_HASH_PROMPT_ATTEMPTS; attempt++) {
+	while (budget.remaining > 0) {
+		budget.remaining--;
 		let answer: TextPromptAnswer;
 		try {
 			answer = await promptText({
 				type: 'text',
 				name: 'transactionHash',
 				message: `Transaction hash executed for ${from} (or "${CANNOT_SIGN_ANSWER}")`,
+				// A HINT the runtime may ignore (see `TextPromptRequest`): where it is honoured
+				// the human presses enter to try the same hash again, or types a corrected one.
+				...(previousAnswer === undefined ? {} : {initial: previousAnswer}),
 			});
 		} catch (err) {
 			// A prompt that cannot really reach a human (no TTY behind it) must not replace
@@ -126,16 +185,27 @@ export async function askForExecutedTransactionHash(params: {
 			return {type: 'hash', hash: value.toLowerCase() as `0x${string}`};
 		}
 
-		const remaining = MAX_HASH_PROMPT_ATTEMPTS - attempt;
 		showMessage(
 			`"${value}" is not a transaction hash (expected 0x followed by 64 hex characters).` +
-				(remaining > 0
-					? ` ${remaining} attempt${remaining === 1 ? '' : 's'} left.`
-					: ' Giving up and deferring the transaction.'),
+				describeRemainingAttempts(budget),
 		);
 	}
 
-	return {type: 'cannot-sign', reason: 'no-valid-hash'};
+	return {type: 'cannot-sign', reason: 'attempts-exhausted'};
+}
+
+/**
+ * The tail of every "that answer was no good" message: how much of the shared budget is
+ * left, or that the pause is over.
+ *
+ * ONE phrasing for both re-ask paths, because they spend one budget: a user who met a
+ * malformed-paste message and then a not-found one has to be able to read the two
+ * countdowns as the same countdown, which they are.
+ */
+export function describeRemainingAttempts(budget: HashPromptBudget): string {
+	return budget.remaining > 0
+		? ` ${budget.remaining} attempt${budget.remaining === 1 ? '' : 's'} left.`
+		: ' Giving up and deferring the transaction.';
 }
 
 /** What a human types to accept a transaction rocketh could not tie to the request. */

--- a/packages/rocketh/test/interactive-deployment-address.test.ts
+++ b/packages/rocketh/test/interactive-deployment-address.test.ts
@@ -9,6 +9,7 @@ import type {
 	PartialDeployment,
 	PromptExecutor,
 	TextPromptAnswer,
+	TextPromptRequest,
 	UnknownSignerPolicy,
 	UserConfig,
 } from '@rocketh/core/types';
@@ -42,6 +43,8 @@ const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111';
 const SENT_TX_HASH = '0x0000000000000000000000000000000000000000000000000000000000000011' as `0x${string}`;
 /** What the human pastes back after executing the deployment on their Safe. */
 const PASTED_HASH = '0x00000000000000000000000000000000000000000000000000000000000000aa' as `0x${string}`;
+/** A well-formed hash this node has never heard of: the paste that gets RE-ASKED. */
+const NOT_FOUND_HASH = '0x00000000000000000000000000000000000000000000000000000000000000cc' as `0x${string}`;
 const GENESIS_HASH = '0x0000000000000000000000000000000000000000000000000000000000000042';
 
 /** The address the pasted transaction's receipt says was created. */
@@ -62,8 +65,11 @@ function createMockProvider(options?: {
 	code?: Record<string, `0x${string}`>;
 	/** Make `eth_getCode` FAIL, as a node having an outage would. */
 	codeLookupError?: string;
+	/** Hashes this node has never heard of: no transaction and no receipt, ever. */
+	unknownHashes?: string[];
 }): {provider: EIP1193ProviderWithoutEvents; calls: Call[]} {
 	const calls: Call[] = [];
+	const unknownHashes = new Set((options?.unknownHashes ?? []).map((h) => h.toLowerCase()));
 	const code: Record<string, `0x${string}`> = {};
 	for (const [address, value] of Object.entries(options?.code ?? {})) {
 		code[address.toLowerCase()] = value;
@@ -90,10 +96,16 @@ function createMockProvider(options?: {
 					return code[(args.params as string[])[0].toLowerCase()] ?? '0x';
 				case 'eth_getTransactionByHash': {
 					const hash = (args.params as string[])[0];
+					if (unknownHashes.has(hash.toLowerCase())) {
+						return null;
+					}
 					return {hash, nonce: '0x3', from: SAFE_ADDRESS, gasPrice: '0x1', type: '0x0'};
 				}
 				case 'eth_getTransactionReceipt': {
 					const hash = (args.params as string[])[0];
+					if (unknownHashes.has(hash.toLowerCase())) {
+						return null;
+					}
 					return {
 						transactionHash: hash,
 						blockHash: '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -148,11 +160,17 @@ function createInMemoryStore(): {store: DeploymentStore; writes: {name: string; 
 	return {store, writes};
 }
 
-type ScriptedPrompt = PromptExecutor & {promptText: ReturnType<typeof vi.fn>};
+type ScriptedPrompt = PromptExecutor & {promptText: ReturnType<typeof vi.fn>; requests: TextPromptRequest[]};
 
-/** A prompt driven by a SCRIPT of answers, so the interactive path runs with no TTY. */
+/**
+ * A prompt driven by a SCRIPT of answers, so the interactive path runs with no TTY.
+ * It records the whole request, `initial` included, so a test can assert what the
+ * human was OFFERED as a starting point on a re-ask.
+ */
 function createScriptedPrompt(answers: TextPromptAnswer[]): ScriptedPrompt {
-	const promptText = vi.fn(async () => {
+	const requests: TextPromptRequest[] = [];
+	const promptText = vi.fn(async (request: TextPromptRequest) => {
+		requests.push(request);
 		const next = answers.shift();
 		if (next === undefined) {
 			throw new Error('scripted prompt: asked more times than the test scripted answers for');
@@ -165,6 +183,7 @@ function createScriptedPrompt(answers: TextPromptAnswer[]): ScriptedPrompt {
 		},
 		promptText,
 		exit() {},
+		requests,
 	};
 }
 
@@ -176,12 +195,14 @@ async function buildEnvironment(options: {
 	receipts?: Record<string, Record<string, unknown>>;
 	code?: Record<string, `0x${string}`>;
 	codeLookupError?: string;
+	unknownHashes?: string[];
 }) {
 	const {provider, calls} = createMockProvider({
 		accounts: options.nodeAccounts,
 		receipts: options.receipts,
 		code: options.code,
 		codeLookupError: options.codeLookupError,
+		unknownHashes: options.unknownHashes,
 	});
 	const {store, writes} = createInMemoryStore();
 	const config = resolveConfig({
@@ -291,6 +312,35 @@ describe('interactive deployment - the address comes from the pasted transaction
 		expect(codeCalls).toHaveLength(1);
 		expect((codeCalls[0].params as string[])[0]).toBe(EXPECTED_ADDRESS);
 	});
+
+	/**
+	 * BOTH FUNNELS BEHAVE THE SAME, because they reach one choke point: a deployment
+	 * whose pasted hash this node has never heard of is RE-ASKED with that hash offered
+	 * back, exactly as an execution is, and the deployment is then recorded for the hash
+	 * finally accepted.
+	 */
+	it('re-asks a hash this node cannot find and records the one finally accepted', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: PASTED_HASH}]);
+		const {env, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+
+		const deployment = await env.broadcastDeployment(
+			DEPLOYMENT_NAME,
+			deploymentTransaction(env.resolveAccount('admin')),
+			partialDeployment,
+		);
+
+		expect(deployment.transaction?.hash).toBe(PASTED_HASH);
+		expect(deployment.address).toBe(DEPLOYED_ADDRESS);
+		expect(promptExecutor.requests[1].initial).toBe(NOT_FOUND_HASH);
+		expect(JSON.parse(deploymentWrites(writes)[0].content).address).toBe(DEPLOYED_ADDRESS);
+		// only the accepted hash is counted for gas reporting
+		expect(env.network.provider.transactionHashes).toEqual([PASTED_HASH]);
+	});
 });
 
 describe('interactive deployment - a bad hash fails loudly and saves nothing', () => {
@@ -376,6 +426,36 @@ describe('interactive deployment - a bad hash fails loudly and saves nothing', (
 	 * The ordinary half, shape one: the pasted transaction created no contract at all,
 	 * so its receipt carries NO contract address.
 	 */
+	/**
+	 * The address invariants run on the hash FINALLY ACCEPTED, not on the first one
+	 * pasted: a re-ask that ends in a hash which deployed nothing must still fail and
+	 * still save nothing. Written with the second hash failing precisely because the
+	 * first one never got that far — an implementation that checked the earlier answer,
+	 * or skipped the check after a re-ask, would record a deployment here.
+	 */
+	it('runs the address invariants on the re-asked hash, and saves nothing when it created no contract', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: PASTED_HASH}]);
+		const {env, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			unknownHashes: [NOT_FOUND_HASH],
+			receipts: {[PASTED_HASH]: {contractAddress: undefined}},
+		});
+
+		const from = env.resolveAccount('admin');
+		const error = await env.broadcastDeployment(DEPLOYMENT_NAME, deploymentTransaction(from), partialDeployment).then(
+			() => undefined,
+			(e) => e,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(PASTED_HASH);
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(2);
+		expect(writes).toEqual([]);
+		expect(env.network.provider.transactionHashes).toEqual([]);
+	});
+
 	it('fails when the receipt carries no contract address', async () => {
 		const promptExecutor = createScriptedPrompt([{value: PASTED_HASH}]);
 		const {env, writes} = await buildEnvironment({

--- a/packages/rocketh/test/interactive-unknown-signer.test.ts
+++ b/packages/rocketh/test/interactive-unknown-signer.test.ts
@@ -3,12 +3,14 @@ import {LOCAL_SIGNING_RPC_RESPONSES} from './support/local-signing-responses.js'
 
 import {resolveConfig, getChainIdForEnvironment, resolveExecutionParams} from '../src/executor/index.js';
 import {createEnvironment, PASTED_TRANSACTION_LOOKUP_ROUNDS} from '../src/environment/index.js';
+import {MAX_HASH_PROMPT_ATTEMPTS} from '../src/environment/interactiveUnknownSigner.js';
 import {privateKey} from '@rocketh/signer';
 import {UnknownSignerError} from '@rocketh/core';
 import type {
 	DeploymentStore,
 	PromptExecutor,
 	TextPromptAnswer,
+	TextPromptRequest,
 	UnknownSignerPolicy,
 	UserConfig,
 } from '@rocketh/core/types';
@@ -46,6 +48,12 @@ const SENT_TX_HASH = '0x00000000000000000000000000000000000000000000000000000000
 /** What the human pastes back after executing on their Safe. */
 const PASTED_HASH = '0x00000000000000000000000000000000000000000000000000000000000000aa' as `0x${string}`;
 const SECOND_PASTED_HASH = '0x00000000000000000000000000000000000000000000000000000000000000bb' as `0x${string}`;
+/**
+ * A perfectly well-formed hash this node has never heard of, and never will: a
+ * character the terminal ate, a hash copied from the wrong chain's explorer. It is
+ * what the RE-ASK exists for, and what the malformed-paste re-ask cannot catch.
+ */
+const NOT_FOUND_HASH = '0x00000000000000000000000000000000000000000000000000000000000000cc' as `0x${string}`;
 const GENESIS_HASH = '0x0000000000000000000000000000000000000000000000000000000000000042';
 
 type Call = {method: string; params?: unknown};
@@ -71,6 +79,12 @@ function createMockProvider(options?: {
 	receipts?: Record<string, Record<string, unknown>>;
 	/** Hashes this node has never heard of: no transaction and no receipt, ever. */
 	unknownHashes?: string[];
+	/**
+	 * Hashes the node does not know YET: `eth_getTransactionByHash` answers null for the
+	 * first N asks and then knows it. Models the RPC catching up with a transaction that
+	 * really was executed, which is the case where re-submitting the SAME hash resolves.
+	 */
+	unknownTransactionRounds?: Record<string, number>;
 	/** Hashes the node knows but has not mined yet: no receipt for the first N asks. */
 	pendingReceiptRounds?: Record<string, number>;
 	/**
@@ -91,6 +105,7 @@ function createMockProvider(options?: {
 	const calls: Call[] = [];
 	const unknownHashes = new Set((options?.unknownHashes ?? []).map((h) => h.toLowerCase()));
 	const pendingRoundsLeft: Record<string, number> = {...options?.pendingReceiptRounds};
+	const unknownTransactionRoundsLeft: Record<string, number> = {...options?.unknownTransactionRounds};
 	const provider = {
 		request: (async (args: {method: string; params?: unknown}) => {
 			calls.push({method: args.method, params: args.params});
@@ -111,6 +126,10 @@ function createMockProvider(options?: {
 				case 'eth_getTransactionByHash': {
 					const hash = (args.params as string[])[0];
 					if (unknownHashes.has(hash.toLowerCase())) {
+						return null;
+					}
+					if (unknownTransactionRoundsLeft[hash] > 0) {
+						unknownTransactionRoundsLeft[hash]--;
 						return null;
 					}
 					// `to`, `input` and `value` are always present on a real `eth_getTransactionByHash`
@@ -189,7 +208,7 @@ function createInMemoryStore(): {
 
 type ScriptedPrompt = PromptExecutor & {
 	promptText: ReturnType<typeof vi.fn>;
-	requests: {type: 'text'; name: string; message: string}[];
+	requests: TextPromptRequest[];
 };
 
 /**
@@ -197,10 +216,15 @@ type ScriptedPrompt = PromptExecutor & {
  * no TTY. An entry that is an `Error` is THROWN by `promptText` (a runtime that
  * cannot really reach a human); running past the end of the script fails loudly
  * rather than looping forever.
+ *
+ * It records the WHOLE request, `initial` included, so a test can assert what the
+ * human was OFFERED as a starting point and not merely how often they were asked.
+ * The script answers regardless of what was offered, exactly as a human is free to
+ * type over it.
  */
 function createScriptedPrompt(answers: (TextPromptAnswer | Error)[]): ScriptedPrompt {
-	const requests: {type: 'text'; name: string; message: string}[] = [];
-	const promptText = vi.fn(async (request: {type: 'text'; name: string; message: string}) => {
+	const requests: TextPromptRequest[] = [];
+	const promptText = vi.fn(async (request: TextPromptRequest) => {
 		requests.push(request);
 		const next = answers.shift();
 		if (next === undefined) {
@@ -254,6 +278,7 @@ async function buildEnvironment(options: {
 	saveDeployments?: boolean;
 	receipts?: Record<string, Record<string, unknown>>;
 	unknownHashes?: string[];
+	unknownTransactionRounds?: Record<string, number>;
 	pendingReceiptRounds?: Record<string, number>;
 	transactions?: Record<string, Record<string, unknown>>;
 	latestBlockNumber?: string;
@@ -262,6 +287,7 @@ async function buildEnvironment(options: {
 		accounts: options.nodeAccounts,
 		receipts: options.receipts,
 		unknownHashes: options.unknownHashes,
+		unknownTransactionRounds: options.unknownTransactionRounds,
 		pendingReceiptRounds: options.pendingReceiptRounds,
 		transactions: options.transactions,
 		latestBlockNumber: options.latestBlockNumber,
@@ -745,12 +771,16 @@ describe('interactive resolver - receipt invariants', () => {
 	/**
 	 * A hash this node has NEVER heard of (pasted from the wrong chain, or a plausible
 	 * typo that is still 64 hex characters) must not park the run behind a spinner for
-	 * ever: the lookup is BOUNDED, and giving up names the hash as not found and hands
-	 * back the transaction that still needs executing. The test finishing at all is half
-	 * the assertion: an unbounded poll would hang it until the suite timeout.
+	 * ever: the lookup for ONE hash is BOUNDED. Giving up on it no longer ends the run
+	 * though — see the re-ask suite below — so what this pins is the bound itself: one
+	 * hash costs at most `PASTED_TRANSACTION_LOOKUP_ROUNDS` lookups, it never reaches a
+	 * receipt, and it records nothing. The test finishing at all is half the assertion:
+	 * an unbounded poll would hang it until the suite timeout.
 	 */
-	it('gives up on a hash this node has never seen, naming it as not found', async () => {
-		const promptExecutor = createScriptedPrompt([{value: PASTED_HASH}]);
+	it('stops looking for a hash this node has never seen, after a bounded number of rounds', async () => {
+		// The re-ask is declined, so this stays about the LOOKUP bound for ONE hash; the
+		// re-ask itself is exercised on its own below.
+		const promptExecutor = createScriptedPrompt([{value: PASTED_HASH}, {value: 'cannot sign'}]);
 		const {env, calls, writes} = await buildEnvironment({
 			accounts: {admin: SAFE_ADDRESS},
 			onUnknownSigner: 'ask',
@@ -758,6 +788,7 @@ describe('interactive resolver - receipt invariants', () => {
 			saveDeployments: true,
 			unknownHashes: [PASTED_HASH],
 		});
+		const shown = captureMessages(env);
 
 		const from = env.resolveAccount('admin');
 		const error = await env.broadcastExecution(safeTransaction(from)).then(
@@ -766,9 +797,10 @@ describe('interactive resolver - receipt invariants', () => {
 		);
 
 		expect(error).toBeInstanceOf(Error);
-		expect((error as Error).message).toContain(PASTED_HASH);
-		expect((error as Error).message).toContain('not found');
-		// the transaction that still needs executing comes back with it
+		// the hash and the reason are SHOWN, which is where they belong once the run goes on
+		expect(shown.join('\n')).toContain(PASTED_HASH);
+		expect(shown.join('\n')).toContain('was not found on this network');
+		// the transaction that still needs executing comes back with the deferral
 		expect((error as Error).message).toContain('0xdeadbeef');
 		// bounded: it stopped asking rather than polling for ever
 		expect(calls.filter((c) => c.method === 'eth_getTransactionByHash').length).toBeLessThanOrEqual(
@@ -846,6 +878,233 @@ describe('interactive resolver - receipt invariants', () => {
 		expect(
 			calls.filter((c) => c.method === 'eth_getTransactionReceipt' && (c.params as string[])[0] === PASTED_HASH),
 		).toHaveLength(2);
+	});
+});
+
+/**
+ * THE RE-ASK for a hash this node cannot find.
+ *
+ * Giving up on such a hash used to END THE RUN, which threw away everything the human
+ * had typed for the commonest, most trivial causes: a truncated paste, a character the
+ * terminal ate, the right hash a moment before the RPC caught up. Now the question is
+ * asked AGAIN with that hash offered back, so the fix costs an edit.
+ *
+ * Two properties hold this together and each has a test below. The re-ask is BOUNDED,
+ * because the failure it replaced existed to stop a run hanging for ever on a hash no
+ * node will ever know. And the bound is ONE budget shared with the malformed-paste
+ * re-ask that already existed, because two budgets that each reset can be alternated
+ * for ever.
+ *
+ * Note that "it threw `UnknownSignerError`" is NOT discriminating here: a run that never
+ * went interactive throws the same thing. These assert on what was ASKED (the requests,
+ * `initial` included) and what was SHOWN.
+ */
+describe('interactive resolver - a hash this node cannot find is re-asked, pre-filled', () => {
+	/**
+	 * The headline: the previous answer comes back as the prompt's starting value, the
+	 * human corrects it, and the run resolves on the CORRECTED hash. Nothing is recorded
+	 * for the hash that was never found — in particular it does not reach the gas tracker.
+	 */
+	it('re-asks with the previous answer pre-filled, and resolves on the corrected hash', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: PASTED_HASH}]);
+		const {env, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			saveDeployments: true,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+		const shown = captureMessages(env);
+
+		const receipt = await env.broadcastExecution(safeTransaction(env.resolveAccount('admin')));
+
+		expect(receipt.transactionHash).toBe(PASTED_HASH);
+		// WHAT WAS ASKED: the same question twice, the second time carrying the first answer.
+		expect(promptExecutor.requests).toHaveLength(2);
+		expect(promptExecutor.requests[0].initial).toBeUndefined();
+		expect(promptExecutor.requests[1].initial).toBe(NOT_FOUND_HASH);
+		// WHAT WAS SHOWN: why it is asking again, and how many goes are left.
+		expect(shown.join('\n')).toContain(`(${NOT_FOUND_HASH}) was not found on this network`);
+		expect(shown.join('\n')).toContain('attempts left.');
+		// only the accepted hash was tracked or saved
+		expect(env.network.provider.transactionHashes).toEqual([PASTED_HASH]);
+		expect(writes.find((w) => w.name === '.pending_transactions.json')?.content).not.toContain(NOT_FOUND_HASH);
+	});
+
+	/**
+	 * The other half of the same story: the hash was RIGHT, this node just had not caught
+	 * up with it. Submitting the offered value unchanged (what pressing enter on the
+	 * pre-filled prompt sends) looks it up again, and the second look finds it.
+	 */
+	it('retries the same hash when the previous answer is submitted unchanged', async () => {
+		const promptExecutor = createScriptedPrompt([{value: PASTED_HASH}, {value: PASTED_HASH}]);
+		const {env, calls} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			// unknown for exactly as long as the first ask is willing to look
+			unknownTransactionRounds: {[PASTED_HASH]: MAX_LOOKUPS_FOR_AN_UNKNOWN_HASH},
+		});
+
+		const receipt = await env.broadcastExecution(safeTransaction(env.resolveAccount('admin')));
+
+		expect(receipt.transactionHash).toBe(PASTED_HASH);
+		expect(promptExecutor.requests[1].initial).toBe(PASTED_HASH);
+		// it really did look a second time, rather than reusing the first verdict
+		expect(calls.filter((c) => c.method === 'eth_getTransactionByHash').length).toBeGreaterThan(
+			MAX_LOOKUPS_FOR_AN_UNKNOWN_HASH,
+		);
+		expect(env.network.provider.transactionHashes).toEqual([PASTED_HASH]);
+	});
+
+	/**
+	 * THE BOUND, which is the property the replaced failure existed to provide: a human
+	 * who never supplies a findable hash reaches a terminal outcome in FINITE time. The
+	 * proof is a COUNT, not a clock: exactly `MAX_HASH_PROMPT_ATTEMPTS` questions are
+	 * asked and then the transaction defers, so this test cannot pass by being slow and
+	 * cannot hang if the bound is removed — the scripted prompt would run out of answers.
+	 */
+	it('gives up after a bounded number of not-found hashes and defers, saving nothing', async () => {
+		const answers = [
+			{value: NOT_FOUND_HASH},
+			{value: NOT_FOUND_HASH},
+			{value: NOT_FOUND_HASH},
+			{value: NOT_FOUND_HASH},
+			{value: NOT_FOUND_HASH},
+		];
+		const promptExecutor = createScriptedPrompt(answers);
+		const {env, calls, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			saveDeployments: true,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+		const shown = captureMessages(env);
+
+		const from = env.resolveAccount('admin');
+		const error = await env.broadcastExecution(safeTransaction(from)).then(
+			() => undefined,
+			(e) => e,
+		);
+
+		// DEFERS: the same undegraded error every other giving-up exit produces, so a
+		// `catchUnknownSigner` wrapper handles it identically.
+		expect(error).toBeInstanceOf(UnknownSignerError);
+		expect((error as Error).message).toContain('0xdeadbeef');
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(MAX_HASH_PROMPT_ATTEMPTS);
+		expect(answers).toHaveLength(5 - MAX_HASH_PROMPT_ATTEMPTS);
+		expect(shown.join('\n')).toContain('Giving up and deferring the transaction.');
+		// NOTHING was saved or tracked for a transaction that does not exist
+		expect(writes).toEqual([]);
+		expect(env.network.provider.transactionHashes).toEqual([]);
+		expect(calls.filter((c) => c.method === 'eth_getTransactionReceipt')).toEqual([]);
+	});
+
+	/**
+	 * THE SHARED BUDGET. The malformed-paste re-ask and this one spend ONE counter, so
+	 * alternating the two kinds of bad answer cannot refill either. Two independent
+	 * budgets would let this script run for ever; one budget stops it at
+	 * `MAX_HASH_PROMPT_ATTEMPTS` questions, whatever the mix.
+	 */
+	it('cannot be looped for ever by alternating malformed and not-found answers', async () => {
+		const answers = [
+			{value: 'not-a-hash'},
+			{value: NOT_FOUND_HASH},
+			{value: 'still not a hash'},
+			{value: NOT_FOUND_HASH},
+			{value: 'nor this'},
+			{value: NOT_FOUND_HASH},
+		];
+		const promptExecutor = createScriptedPrompt(answers);
+		const {env, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			saveDeployments: true,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+
+		await expect(env.broadcastExecution(safeTransaction(env.resolveAccount('admin')))).rejects.toBeInstanceOf(
+			UnknownSignerError,
+		);
+
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(MAX_HASH_PROMPT_ATTEMPTS);
+		expect(answers).toHaveLength(6 - MAX_HASH_PROMPT_ATTEMPTS);
+		expect(writes).toEqual([]);
+	});
+
+	/**
+	 * The exits are the same from the RE-ASKED question as from the first one: the human
+	 * who cannot find the hash after all must be able to walk away with the transaction,
+	 * not be held at a prompt they cannot satisfy. All three produce the ordinary
+	 * deferral.
+	 */
+	it('defers on an empty answer at the re-asked prompt', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: '  '}]);
+		const {env, writes} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			saveDeployments: true,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+
+		await expect(env.broadcastExecution(safeTransaction(env.resolveAccount('admin')))).rejects.toBeInstanceOf(
+			UnknownSignerError,
+		);
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(2);
+		expect(writes).toEqual([]);
+	});
+
+	it('defers on "cannot sign" at the re-asked prompt', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: 'cannot sign'}]);
+		const {env} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+
+		await expect(env.broadcastExecution(safeTransaction(env.resolveAccount('admin')))).rejects.toBeInstanceOf(
+			UnknownSignerError,
+		);
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(2);
+	});
+
+	it('defers when the re-asked prompt is aborted', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {cancelled: true}]);
+		const {env} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+
+		await expect(env.broadcastExecution(safeTransaction(env.resolveAccount('admin')))).rejects.toBeInstanceOf(
+			UnknownSignerError,
+		);
+		expect(promptExecutor.promptText).toHaveBeenCalledTimes(2);
+	});
+
+	/**
+	 * The pause banner (the transaction to execute, and the note that an old hash is
+	 * welcome) is printed ONCE per pause, not once per question: the re-ask happens under
+	 * the banner the human is still looking at.
+	 */
+	it('does not reprint the transaction banner on the re-ask', async () => {
+		const promptExecutor = createScriptedPrompt([{value: NOT_FOUND_HASH}, {value: PASTED_HASH}]);
+		const {env} = await buildEnvironment({
+			accounts: {admin: SAFE_ADDRESS},
+			onUnknownSigner: 'ask',
+			promptExecutor,
+			unknownHashes: [NOT_FOUND_HASH],
+		});
+		const shown = captureMessages(env);
+
+		await env.broadcastExecution(safeTransaction(env.resolveAccount('admin')));
+
+		expect(shown.filter((message) => message.includes('this run is PAUSED'))).toHaveLength(1);
 	});
 });
 

--- a/work/tasks/done/re-ask-a-not-found-pasted-hash-with-the-previous-value.md
+++ b/work/tasks/done/re-ask-a-not-found-pasted-hash-with-the-previous-value.md
@@ -73,3 +73,17 @@ git fetch <remote> && git switch -c work/<slug> <remote>/main
 # on completion, in the work branch's PR/merge:
 git mv work/tasks/ready/<slug>.md work/tasks/done/<slug>.md
 ```
+
+## Decisions
+
+**1. One SHARED budget of 3 questions per pause, not two.** The malformed-paste re-ask and the new not-found re-ask spend one `HashPromptBudget` created per unsignable transaction. Alternative considered: a separate not-found budget, rejected because two counters that each reset can be alternated for ever, which is exactly the unbounded loop the old hard failure existed to prevent. Kept at the existing `MAX_HASH_PROMPT_ATTEMPTS = 3` rather than raising it, so the malformed path's observable behaviour is unchanged. Touches: `MAX_HASH_PROMPT_ATTEMPTS` (re-meaned from "malformed attempts" to "text asks per pause", documented at the constant), and any future third re-ask, which must spend this budget too. Pinned by `cannot be looped for ever by alternating malformed and not-found answers`.
+
+**2. Exhausting the budget DEFERS, it does not fail.** A not-found hash used to throw a plain `Error` naming the hash; now the run shows that message and, when the budget is gone, throws the undegraded `UnknownSignerError` exactly as "cannot sign" does. Alternative considered: keep the bespoke terminal `Error` for the not-found spender. Rejected because with a shared budget the outcome would depend on which kind of answer happened to spend the last unit, and because a plain `Error` escapes `catchUnknownSigner` and kills a run that the deferral workflow could have handled. Consequence, user-visible: a wrapper that previously died on a not-found hash now catches it and continues. Touches: `catchUnknownSigner` / `@rocketh/unknown-signer` consumers; covered by the changeset.
+
+**3. The resolver's `cannot-sign` reason `no-valid-hash` was renamed `attempts-exhausted`.** Internal (not exported from the package, only used in a `logger.debug`), but the old name says "malformed", which becomes a lie once a never-found hash can spend the same budget.
+
+**4. `previousAnswer` also suppresses the banner.** Its presence means "this is a re-ask within the same pause", so `formatInteractivePresentation` is printed once per pause rather than once per question, matching what the malformed loop already did. Alternative: a separate boolean flag, rejected as a second knob for one state. Documented at the parameter and pinned by `does not reprint the transaction banner on the re-ask`.
+
+**5. Documentation went to `documentation/unknown-signers/index.md`, not `documentation.md`.** The task names a `documentation.md` that no longer exists: the docs are now the `documentation/` site (per `work/notes/ideas/docs-site-astro-starlight.md`), and the interactive-flow text the task describes verbatim lives on the unknown-signers page. Small and self-contained, so I resolved it rather than stopping, but recording it since the task text is stale.
+
+**New named concept:** `HashPromptBudget` / `createHashPromptBudget` in `interactiveUnknownSigner.ts`. Checked against `CONTEXT.md` and the ADRs: it duplicates nothing (no existing "budget", "attempts" or "quota" concept), sits at the prompt-loop layer where both re-asks can reach it, and is module-internal, so it is not added to the glossary.


### PR DESCRIPTION
Task: `work/tasks/done/re-ask-a-not-found-pasted-hash-with-the-previous-value.md`

Done. All checks green: `pnpm build`, `pnpm typecheck`, `pnpm test` (102 files, 1240 tests), `pnpm format:check`.

## What I built

**Drift check first.** The task's premises all still hold: `waitForPastedTransaction` did throw on a not-found hash after `PASTED_TRANSACTION_LOOKUP_ROUNDS` (`packages/rocketh/src/environment/index.ts`), the malformed-paste re-ask exists at `MAX_HASH_PROMPT_ATTEMPTS = 3` (`interactiveUnknownSigner.ts`), `promptText` was `{type, name, message}` and optional, `@rocketh/web` ships no text ability, and ADRs 0006/0007 are unchanged. The only stale detail was the doc path (see Decisions).

- **`@rocketh/core`** — new `TextPromptRequest` type with an optional `initial`, documented as a HINT an implementation may ignore; `PromptExecutor.promptText` now takes it. Purely additive: existing implementations still typecheck.
- **`@rocketh/node`** — the request reaches `prompts` whole, which supports `initial` natively. JSDoc pins what that actually means there (greyed placeholder, submitted on an untouched enter, right-arrow pulls it into the buffer) and that Ctrl-C still reads as a cancellation, verified against the installed `prompts@2.4.2` source.
- **`@rocketh/test-utils`** — `MockTextPromptRequest` is now the request type itself, so `textRequests[i].initial` records what was pre-filled.
- **`rocketh` seam** — `waitForPastedTransaction` returns `{type: 'not-found'}` instead of throwing (a non-success receipt still throws, deliberately). The choke point wraps ask + lookup in a loop that re-asks with the previous hash as `previousAnswer`, and a shared `HashPromptBudget` is spent by both the malformed loop (inside the resolver) and the not-found re-ask (at the seam). The refusals stay before the pending file, gas tracker and deployment record; the address invariants run on the hash finally accepted.
- **Tests** — 8 new at the execution seam (pre-fill asserted via the recorded request, unchanged-value retry, bounded give-up by call COUNT not clock, alternating malformed/not-found, the three exits from the re-asked prompt, banner printed once), 2 at the deployment funnel (including one where the *re-asked* hash created no contract, so the invariant provably ran on the accepted hash), plus one each in `@rocketh/node` and `@rocketh/test-utils`.
- **Docs** — new "A hash that does not work out is asked again, not fatal" section in `documentation/unknown-signers/index.md`, replacing the sentence that said the run stops.
- **Changeset** — `.changeset/re-ask-a-not-found-pasted-hash.md`, minor for `@rocketh/core`, `@rocketh/node`, `@rocketh/test-utils`, `rocketh`.

## Decisions

**1. One SHARED budget of 3 questions per pause, not two.** The malformed-paste re-ask and the new not-found re-ask spend one `HashPromptBudget` created per unsignable transaction. Alternative considered: a separate not-found budget, rejected because two counters that each reset can be alternated for ever, which is exactly the unbounded loop the old hard failure existed to prevent. Kept at the existing `MAX_HASH_PROMPT_ATTEMPTS = 3` rather than raising it, so the malformed path's observable behaviour is unchanged. Touches: `MAX_HASH_PROMPT_ATTEMPTS` (re-meaned from "malformed attempts" to "text asks per pause", documented at the constant), and any future third re-ask, which must spend this budget too. Pinned by `cannot be looped for ever by alternating malformed and not-found answers`.

**2. Exhausting the budget DEFERS, it does not fail.** A not-found hash used to throw a plain `Error` naming the hash; now the run shows that message and, when the budget is gone, throws the undegraded `UnknownSignerError` exactly as "cannot sign" does. Alternative considered: keep the bespoke terminal `Error` for the not-found spender. Rejected because with a shared budget the outcome would depend on which kind of answer happened to spend the last unit, and because a plain `Error` escapes `catchUnknownSigner` and kills a run that the deferral workflow could have handled. Consequence, user-visible: a wrapper that previously died on a not-found hash now catches it and continues. Touches: `catchUnknownSigner` / `@rocketh/unknown-signer` consumers; covered by the changeset.

**3. The resolver's `cannot-sign` reason `no-valid-hash` was renamed `attempts-exhausted`.** Internal (not exported from the package, only used in a `logger.debug`), but the old name says "malformed", which becomes a lie once a never-found hash can spend the same budget.

**4. `previousAnswer` also suppresses the banner.** Its presence means "this is a re-ask within the same pause", so `formatInteractivePresentation` is printed once per pause rather than once per question, matching what the malformed loop already did. Alternative: a separate boolean flag, rejected as a second knob for one state. Documented at the parameter and pinned by `does not reprint the transaction banner on the re-ask`.

**5. Documentation went to `documentation/unknown-signers/index.md`, not `documentation.md`.** The task names a `documentation.md` that no longer exists: the docs are now the `documentation/` site (per `work/notes/ideas/docs-site-astro-starlight.md`), and the interactive-flow text the task describes verbatim lives on the unknown-signers page. Small and self-contained, so I resolved it rather than stopping, but recording it since the task text is stale.

**New named concept:** `HashPromptBudget` / `createHashPromptBudget` in `interactiveUnknownSigner.ts`. Checked against `CONTEXT.md` and the ADRs: it duplicates nothing (no existing "budget", "attempts" or "quota" concept), sits at the prompt-loop layer where both re-asks can reach it, and is module-internal, so it is not added to the glossary.